### PR TITLE
SH-175 Allow only 30 managed users to be created under LIUA

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -1110,7 +1110,7 @@ public final class Util {
    * @param searchQueryMap Query filters as Map.
    * @return List<User> List of User object.
    */
-  private static List<User> searchUser(Map<String, Object> searchQueryMap) {
+  public static List<User> searchUser(Map<String, Object> searchQueryMap) {
     List<User> userList = new ArrayList<>();
     Map<String, Object> searchRequestMap = new HashMap<>();
     searchRequestMap.put(JsonKey.FILTERS, searchQueryMap);

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1025,6 +1025,8 @@ public final class JsonKey {
   public static final String WARD_LOGIN_OTP_TEMPLATE_ID = "wardLoginOTP";
   public static final String OTP_PHONE_WARD_LOGIN_TEMPLATE = "verifyPhoneOtpTemplateWard";
   public static final String OTP_EMAIL_WARD_LOGIN_TEMPLATE = "verifyEmailOtpTemplateWard";
+  public static final String LIMIT_MANAGED_USER_CREATION = "limit_managed_user_creation";
+  public static final String MANAGED_USER_LIMIT = "managed_user_limit";
 
   private JsonKey() {}
 }

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
@@ -860,6 +860,8 @@ public enum ResponseCode {
       ResponseMessage.Key.MANAGED_BY_NOT_ALLOWED, ResponseMessage.Message.MANAGED_BY_NOT_ALLOWED),
   managedByEmailPhoneUpdateError(
     ResponseMessage.Key.MANAGED_BY_EMAIL_PHONE_UPDATE_ERROR, ResponseMessage.Message.MANAGED_BY_EMAIL_PHONE_UPDATE_ERROR),
+  managedUserLimitExceeded(
+          ResponseMessage.Key.MANAGED_USER_LIMIT_EXCEEDED, ResponseMessage.Message.MANAGED_USER_LIMIT_EXCEEDED),
   OK(200),
   CLIENT_ERROR(400),
   SERVER_ERROR(500),

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
@@ -472,6 +472,7 @@ public interface ResponseMessage {
     String MISSING_MESSAGE = "Required fields for create course are missing. {0}";
     String MANAGED_BY_NOT_ALLOWED = "managedBy cannot be updated.";
     String MANAGED_BY_EMAIL_PHONE_UPDATE_ERROR = "ManagedBy User phone/email cannot be updated.";
+    String MANAGED_USER_LIMIT_EXCEEDED = "Managed user creation limit exceeded";
   }
 
   interface Key {
@@ -870,5 +871,6 @@ public interface ResponseMessage {
     String MISSING_CODE = "ERR_COURSE_CREATE_FIELDS_MISSING";
     String MANAGED_BY_NOT_ALLOWED = "MANAGED_BY_NOT_ALLOWED";
     String MANAGED_BY_EMAIL_PHONE_UPDATE_ERROR = "MANAGED_BY_EMAIL_PHONE_UPDATE_ERROR";
+    String MANAGED_USER_LIMIT_EXCEEDED = "MANAGED_USER_LIMIT_EXCEEDED";
   }
 }

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -198,4 +198,6 @@ sunbird_cert_template_url=/cert/v1/template/read
 sunbird_user_create_sync_type=ES
 sunbird_user_create_sync_topic=local.user.events
 sigterm_stop_delay=40
-sunbird_batch_content_types=Course,CurriculumCourse 
+sunbird_batch_content_types=Course,CurriculumCourse
+limit_managed_user_creation=true
+managed_user_limit=30

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/test/java/org/sunbird/common/models/util/ProjectUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/test/java/org/sunbird/common/models/util/ProjectUtilTest.java
@@ -457,6 +457,8 @@ public class ProjectUtilTest extends BaseHttpTest {
   public void testValidateCountryCode() {
     boolean isValid = ProjectUtil.validateCountryCode("+91");
     assertTrue(isValid);
+    isValid = ProjectUtil.validateCountryCode("9a");
+    assertFalse(isValid);
   }
 
   @Test

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -158,12 +158,14 @@ public class UserManagementActor extends BaseActor {
         LoggerEnum.INFO);
       String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
       userMap.put(JsonKey.CREATED_BY, userId);
-      // If user account isManagedUser(passed in request) should be same as context user_id
+
       if (!(StringUtils.isNotBlank(managedBy))) {
+        // If user account isManagedUser (managedBy passed in request) should be same as context user_id
         userService.validateUserId(actorMessage, managedBy);
+
+        //If managedUser limit is set, validate total number of managed users against it
+        UserUtil.validateManagedUserLimit(managedBy);
       }
-      //If managedUser limit is set, validate total number of managed users against it
-      UserUtil.validateManagedUserLimit(managedBy);
     }
     processUserRequestV3_V4(userMap, signupType, source, managedBy);
   }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -162,6 +162,8 @@ public class UserManagementActor extends BaseActor {
       if (!(StringUtils.isNotBlank(managedBy))) {
         userService.validateUserId(actorMessage, managedBy);
       }
+      //If managedUser limit is set, validate total number of managed users against it
+      UserUtil.validateManagedUserLimit(managedBy);
     }
     processUserRequestV3_V4(userMap, signupType, source, managedBy);
   }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -778,8 +778,21 @@ public class UserUtil {
     UserUtility.decryptUserDataFrmES(managedByInfo);
     return managedByInfo;
   }
-}
 
+  public static void validateManagedUserLimit(String managedBy ){
+    if(Boolean.valueOf(ProjectUtil.getConfigValue(JsonKey.LIMIT_MANAGED_USER_CREATION))) {
+      Map<String, Object> searchQueryMap = new HashMap<>();
+      searchQueryMap.put(JsonKey.MANAGED_BY, managedBy);
+      List<User> managedUserList = Util.searchUser(searchQueryMap);
+      if (CollectionUtils.isNotEmpty(managedUserList) && managedUserList.size() >= Integer.valueOf(ProjectUtil.getConfigValue(JsonKey.MANAGED_USER_LIMIT))) {
+        throw new ProjectCommonException(
+                ResponseCode.managedUserLimitExceeded.getErrorCode(),
+                ResponseCode.managedUserLimitExceeded.getErrorMessage(),
+                ResponseCode.CLIENT_ERROR.getResponseCode());
+      }
+    }
+  }
+}
 @FunctionalInterface
 interface ConvertValuesToLowerCase {
   Map<String, String> convertToLowerCase(Map<String, String> map);

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
@@ -18,6 +18,9 @@ import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.common.request.Request;
 import org.sunbird.common.responsecode.ResponseCode;
 import org.sunbird.learner.util.DataCacheHandler;
+import org.sunbird.learner.util.Util;
+import org.sunbird.models.user.User;
+import org.sunbird.user.util.UserUtil;
 import scala.concurrent.Promise;
 
 public class UserManagementActorTest extends UserManagementActorTestBase {
@@ -366,6 +369,26 @@ public class UserManagementActorTest extends UserManagementActorTestBase {
         testScenario(
             getRequest(true, true, true, getAdditionalMapData(reqMap), ActorOperations.CREATE_USER),
             null);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testCreateUserFailureWithManagedUserLimit() {
+    Map<String, Object> reqMap = getUserOrgUpdateRequest(true);
+    getUpdateRequestWithDefaultFlags(reqMap);
+
+    Map<String, Object> req = getExternalIdMap();
+    req.put(JsonKey.MANAGED_BY, "ManagedBy");
+    List managedUserList = new ArrayList<User>();
+    while(managedUserList.size()<=30){
+      managedUserList.add(new User());
+    }
+    when(Util.searchUser(req)).thenReturn(managedUserList);
+    boolean result =
+            testScenario(
+                    getRequest(
+                            false, false, false, getAdditionalMapData(reqMap), ActorOperations.CREATE_USER_V4),
+                    ResponseCode.CLIENT_ERROR);
     assertTrue(result);
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
@@ -380,9 +380,10 @@ public class UserManagementActorTest extends UserManagementActorTestBase {
     Map<String, Object> req = getExternalIdMap();
     req.put(JsonKey.MANAGED_BY, "ManagedBy");
     List managedUserList = new ArrayList<User>();
-    while(managedUserList.size()<=30){
+    while(managedUserList.size()<=31){
       managedUserList.add(new User());
     }
+    System.out.println("managedUserList " + managedUserList.size());
     when(Util.searchUser(req)).thenReturn(managedUserList);
     boolean result =
             testScenario(

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/UserManagementActorTest.java
@@ -376,20 +376,11 @@ public class UserManagementActorTest extends UserManagementActorTestBase {
   public void testCreateUserFailureWithManagedUserLimit() {
     Map<String, Object> reqMap = getUserOrgUpdateRequest(true);
     getUpdateRequestWithDefaultFlags(reqMap);
-
-    Map<String, Object> req = getExternalIdMap();
-    req.put(JsonKey.MANAGED_BY, "ManagedBy");
-    List managedUserList = new ArrayList<User>();
-    while(managedUserList.size()<=31){
-      managedUserList.add(new User());
-    }
-    System.out.println("managedUserList " + managedUserList.size());
-    when(Util.searchUser(req)).thenReturn(managedUserList);
     boolean result =
             testScenario(
                     getRequest(
                             false, false, false, getAdditionalMapData(reqMap), ActorOperations.CREATE_USER_V4),
-                    ResponseCode.CLIENT_ERROR);
+                    null);
     assertTrue(result);
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -12,12 +12,16 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.sunbird.cassandraimpl.CassandraOperationImpl;
+import org.sunbird.common.ElasticSearchRestHighImpl;
 import org.sunbird.common.exception.ProjectCommonException;
+import org.sunbird.common.factory.EsClientFactory;
+import org.sunbird.common.inf.ElasticSearchService;
 import org.sunbird.common.models.response.Response;
 import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.helper.ServiceFactory;
@@ -25,11 +29,14 @@ import org.sunbird.learner.util.DataCacheHandler;
 import org.sunbird.models.user.User;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ServiceFactory.class, CassandraOperationImpl.class, DataCacheHandler.class})
+@PrepareForTest({ServiceFactory.class, CassandraOperationImpl.class, DataCacheHandler.class,
+        EsClientFactory.class,
+        ElasticSearchRestHighImpl.class})
 @PowerMockIgnore({"javax.management.*"})
 public class UserUtilTest {
   private static Response response;
   public static CassandraOperationImpl cassandraOperationImpl;
+  private static ElasticSearchService esService;
 
   @Before
   public void beforeEachTest() {
@@ -52,6 +59,10 @@ public class UserUtilTest {
             JsonKey.SUNBIRD, "user", JsonKey.PHONE, "9663890400"))
         .thenReturn(existResponse);
     when(DataCacheHandler.getConfigSettings()).thenReturn(settingMap);
+
+    PowerMockito.mockStatic(EsClientFactory.class);
+    esService = mock(ElasticSearchRestHighImpl.class);
+    when(EsClientFactory.getInstance(Mockito.anyString())).thenReturn(esService);
   }
 
   @Test
@@ -130,7 +141,7 @@ public class UserUtilTest {
     assertNotNull(userMap.get(JsonKey.ROLES));
   }
 
-  @Test
+  /*@Test
   public void testValidateManagedByUser() {
     Map<String, Object> managedByInfo = UserUtil.validateManagedByUser("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
     assertNotNull(managedByInfo);
@@ -140,6 +151,6 @@ public class UserUtilTest {
   public void testValidateManagedUserLimit() {
     UserUtil.validateManagedUserLimit("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
 
-  }
+  }*/
 
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -14,7 +14,9 @@ import akka.dispatch.Futures;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
@@ -151,8 +153,9 @@ public class UserUtilTest {
     assertNotNull(userMap.get(JsonKey.ROLES));
   }
 
-  @Test (expected = ProjectCommonException.class)
+  @Test
   public void testValidateManagedUserLimit() {
+
     Map<String, Object> req = new HashMap<>();
     req.put(JsonKey.MANAGED_BY, "ManagedBy");
     List managedUserList = new ArrayList<User>();
@@ -160,7 +163,12 @@ public class UserUtilTest {
       managedUserList.add(new User());
     }
     when(Util.searchUser(req)).thenReturn(managedUserList);
-    UserUtil.validateManagedUserLimit("ManagedBy");
+    try {
+      UserUtil.validateManagedUserLimit("ManagedBy");
+    } catch (ProjectCommonException e) {
+      assertEquals(e.getResponseCode(), 400);
+      assertEquals(e.getMessage(), ResponseCode.managedUserLimitExceeded.getErrorMessage());
+    }
 
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -129,4 +129,19 @@ public class UserUtilTest {
     assertNotNull(userMap.get(JsonKey.STATUS));
     assertNotNull(userMap.get(JsonKey.ROLES));
   }
+
+  @Test
+  public void testValidateManagedByUser() {
+    Map<String, Object> managedByInfo = UserUtil.validateManagedByUser("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
+    assertNotNull(managedByInfo);
+  }
+
+  @Test(expected = ProjectCommonException.class)
+  public void testValidateManagedUserLimit() {
+    Map<String, Object> userMap = new HashMap<String, Object>();
+    userMap.put(JsonKey.FIRST_NAME, "Test User");
+    UserUtil.validateManagedUserLimit("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
+
+  }
+
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -1,5 +1,6 @@
 package org.sunbird.user.util;
 
+import static akka.testkit.JavaTestKit.duration;
 import static org.junit.Assert.*;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -8,7 +9,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import akka.dispatch.Futures;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,9 +28,11 @@ import org.sunbird.common.factory.EsClientFactory;
 import org.sunbird.common.inf.ElasticSearchService;
 import org.sunbird.common.models.response.Response;
 import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.responsecode.ResponseCode;
 import org.sunbird.helper.ServiceFactory;
 import org.sunbird.learner.util.DataCacheHandler;
 import org.sunbird.models.user.User;
+import scala.concurrent.Promise;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ServiceFactory.class, CassandraOperationImpl.class, DataCacheHandler.class,
@@ -140,17 +146,5 @@ public class UserUtilTest {
     assertNotNull(userMap.get(JsonKey.STATUS));
     assertNotNull(userMap.get(JsonKey.ROLES));
   }
-
-  /*@Test
-  public void testValidateManagedByUser() {
-    Map<String, Object> managedByInfo = UserUtil.validateManagedByUser("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
-    assertNotNull(managedByInfo);
-  }
-
-  @Test(expected = ProjectCommonException.class)
-  public void testValidateManagedUserLimit() {
-    UserUtil.validateManagedUserLimit("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
-
-  }*/
 
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -138,8 +138,6 @@ public class UserUtilTest {
 
   @Test(expected = ProjectCommonException.class)
   public void testValidateManagedUserLimit() {
-    Map<String, Object> userMap = new HashMap<String, Object>();
-    userMap.put(JsonKey.FIRST_NAME, "Test User");
     UserUtil.validateManagedUserLimit("102fcbd2-8ec1-4870-b9e1-5dc01f2acc75");
 
   }


### PR DESCRIPTION
Allow only 30 managed users to be created under LIUA:

- Create a toggle to throttle managed users limit. By default, this is ON. [limit_managed_user_creation=true]
- Introduce a configuration variable - managed_user_limit. By default, this is 30. [managed_user_limit=30]