### PR TITLE
SH-373 OTP message fix

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/OTPUtil.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/OTPUtil.java
@@ -69,6 +69,8 @@ public final class OTPUtil {
     String sms = null;
     if (StringUtils.isBlank(template)) {
       sms = OTPService.getSmsBody(JsonKey.VERIFY_PHONE_OTP_TEMPLATE, smsTemplate);
+    } else if (StringUtils.isNotBlank(template) && StringUtils.equals(template, JsonKey.WARD_LOGIN_OTP_TEMPLATE_ID)) {
+      sms = OTPService.getSmsBody(JsonKey.OTP_PHONE_WARD_LOGIN_TEMPLATE, smsTemplate);
     } else {
       sms = OTPService.getSmsBody(JsonKey.OTP_PHONE_RESET_PASSWORD_TEMPLATE, smsTemplate);
     }
@@ -145,6 +147,8 @@ public final class OTPUtil {
     emailTemplateMap.put(JsonKey.RECIPIENT_EMAILS, reciptientsMail);
     if (StringUtils.isBlank((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID))) {
       emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP);
+    } else if (StringUtils.isNotBlank((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID)) && StringUtils.equals((String) emailTemplateMap.get(JsonKey.TEMPLATE_ID), JsonKey.WARD_LOGIN_OTP_TEMPLATE_ID)) {
+      emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP_EMAIL_WARD_LOGIN_TEMPLATE);
     } else {
       // send otp to email while reseting password from portal
       emailTemplateMap.put(JsonKey.EMAIL_TEMPLATE_TYPE, JsonKey.OTP_EMAIL_RESET_PASSWORD_TEMPLATE);


### PR DESCRIPTION
SH-373 When a user is trying to register with a year (<18 years of age) then, OTP message is not displayed as expected. Code was missing due to merge issue.