### PR TITLE
SB 19442 ExternalId table related code changes

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
@@ -1349,7 +1349,7 @@ public class OrganisationManagementActor extends BaseActor {
           JsonKey.EXTERNAL_ID, Util.encryptData((String) data.get(JsonKey.USER_EXTERNAL_ID)));
 
       result =
-          cassandraOperation.getRecordsByCompositeKey(
+          cassandraOperation.getRecordsByProperties(
               JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, requestDbMap);
       fromExtId = true;
     } else {

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -689,7 +689,7 @@ public final class Util {
           externalIdReq.put(JsonKey.ID_TYPE, externalId.get(JsonKey.ID_TYPE));
           externalIdReq.put(JsonKey.EXTERNAL_ID, encryptData(externalId.get(JsonKey.ID)));
           Response response =
-              cassandraOperation.getRecordsByCompositeKey(
+              cassandraOperation.getRecordsByProperties(
                   KEY_SPACE_NAME, JsonKey.USR_EXT_IDNT_TABLE, externalIdReq);
           List<Map<String, Object>> externalIdsRecord =
               (List<Map<String, Object>>) response.get(JsonKey.RESPONSE);
@@ -934,7 +934,7 @@ public final class Util {
     map.remove(JsonKey.CREATED_BY);
     map.remove(JsonKey.LAST_UPDATED_ON);
     map.remove(JsonKey.CREATED_ON);
-    map.remove(JsonKey.USER_ID);
+    map.remove(JsonKey.EXTERNAL_ID);
     map.remove(JsonKey.ORIGINAL_EXTERNAL_ID);
     map.remove(JsonKey.ORIGINAL_ID_TYPE);
     map.remove(JsonKey.ORIGINAL_PROVIDER);

--- a/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/OrgManagementActorTest.java
+++ b/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/OrgManagementActorTest.java
@@ -197,7 +197,7 @@ public class OrgManagementActorTest {
 
   @Test
   public void testAddUserToOrgFailureWithUserNotFoundWithUserExtId() {
-    when(cassandraOperation.getRecordsByCompositeKey(
+    when(cassandraOperation.getRecordsByProperties(
             Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
         .thenReturn(getRecordsByProperty(true));
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
@@ -178,7 +178,7 @@ public class UserExternalIdManagementActor extends BaseActor {
     map.remove(JsonKey.CREATED_BY);
     map.remove(JsonKey.LAST_UPDATED_ON);
     map.remove(JsonKey.CREATED_ON);
-    map.remove(JsonKey.USER_ID);
+    map.remove(JsonKey.EXTERNAL_ID);
     map.remove(JsonKey.ORIGINAL_EXTERNAL_ID);
     map.remove(JsonKey.ORIGINAL_ID_TYPE);
     map.remove(JsonKey.ORIGINAL_PROVIDER);

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
@@ -52,7 +52,7 @@ public class UserExternalIdentityDaoImpl implements UserExternalIdentityDao {
     externalIdReq.put(JsonKey.ID_TYPE, idType.toLowerCase());
     externalIdReq.put(JsonKey.EXTERNAL_ID, extId.toLowerCase());
     Response response =
-        cassandraOperation.getRecordsByCompositeKey(
+        cassandraOperation.getRecordsByProperties(
             usrDbInfo.getKeySpace(), JsonKey.USR_EXT_IDNT_TABLE, externalIdReq);
 
     List<Map<String, Object>> userRecordList =

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -338,7 +338,7 @@ public class UserUtil {
           externalIdReq.put(JsonKey.ID_TYPE, externalId.get(JsonKey.ID_TYPE));
           externalIdReq.put(JsonKey.EXTERNAL_ID, externalId.get(JsonKey.ID));
           Response response =
-              cassandraOperation.getRecordsByCompositeKey(
+              cassandraOperation.getRecordsByProperties(
                   JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, externalIdReq);
           List<Map<String, Object>> externalIdsRecord =
               (List<Map<String, Object>>) response.get(JsonKey.RESPONSE);

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
@@ -94,7 +94,7 @@ public class SupportMultipleExternalIdsTest {
     resMapList.add(externalIdResMap);
     response1.put(JsonKey.RESPONSE, resMapList);
     PowerMockito.when(
-            cassandraOperation.getRecordsByCompositeKey(
+            cassandraOperation.getRecordsByProperties(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
         .thenReturn(response1);
   }


### PR DESCRIPTION
usr_external_identifier table primary key changed from (externalId, provider, idtype) to (userId, provider, idtype).

The reads happening from the table was mostly with userId only. It was using 'allow filtering' and searching based on secondary indexing. This puts a load on all cassandra nodes in the cluster.
Given that the primary key has now changed we can query by properties itself. This will put load only on the particular node, where the record exists. 