### PR TITLE
Issue #SB-19549 Fix start time type for telemetry

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
@@ -166,7 +166,6 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
         LoggerEnum.INFO.name());
     contextMap.put(JsonKey.ACTOR_TYPE, StringUtils.capitalize(JsonKey.SYSTEM));
     contextMap.put(JsonKey.ACTOR_ID, ProjectUtil.getUniqueIdFromTimestamp(0));
-    Iterables.removeIf(contextMap.values(), value -> StringUtils.isBlank(value));
     return contextMap;
   }
 


### PR DESCRIPTION
portal faced issue while uploading shadowuser details.
problem : Request object contains "starttime" key which is of long type and previously for processing telemetry we had a empty check for strings in the Request map.

Empty check is not necessary. 