### PR TITLE
SH-691 save location id instead of location codes

### DIFF
--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/actor-util/src/main/java/org/sunbird/actorutil/location/LocationClient.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/actor-util/src/main/java/org/sunbird/actorutil/location/LocationClient.java
@@ -37,6 +37,8 @@ public interface LocationClient {
    */
   Location getLocationByCode(ActorRef actorRef, String locationCode);
 
+  List<Location> getLocationByCodes(ActorRef actorRef, List<String> locationCode);
+
   /**
    * @desc This method will create Location and returns the response.
    * @param actorRef Actor reference.

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/actor-util/src/main/java/org/sunbird/actorutil/location/impl/LocationClientImpl.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/actor-util/src/main/java/org/sunbird/actorutil/location/impl/LocationClientImpl.java
@@ -87,6 +87,18 @@ public class LocationClientImpl implements LocationClient {
   }
 
   @Override
+  public List<Location> getLocationByCodes(ActorRef actorRef, List<String> locationCode) {
+    String param = GeoLocationJsonKey.CODE;
+    Object value = locationCode;
+    List<Location> locationList = getSearchResponse(actorRef, param, value);
+    if (CollectionUtils.isNotEmpty(locationList)) {
+      return locationList;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
   public String createLocation(ActorRef actorRef, UpsertLocationRequest location) {
     Request request = new Request();
     String locationId = null;

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1054,6 +1054,8 @@ public final class JsonKey {
   public static final String CAPTCHA_SECRET = "captcha_secret";
   public static final String CAPTCHA_RESPONSE = "captchaResponse";
   public static final String ENABLE_CAPTCHA = "enable_captcha";
+  public static final String DECLARED_STATE = "declared-state";
+  public static final String DECLARED_DISTRICT = "declared-district";
 
   private JsonKey() {}
 }

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1056,7 +1056,7 @@ public final class JsonKey {
   public static final String ENABLE_CAPTCHA = "enable_captcha";
   public static final String DECLARED_STATE = "declared-state";
   public static final String DECLARED_DISTRICT = "declared-district";
-  public static final String PENDING = "pending";
+  public static final String PENDING = "PENDING";
 
   private JsonKey() {}
 }

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1056,6 +1056,7 @@ public final class JsonKey {
   public static final String ENABLE_CAPTCHA = "enable_captcha";
   public static final String DECLARED_STATE = "declared-state";
   public static final String DECLARED_DISTRICT = "declared-district";
+  public static final String PENDING = "pending";
 
   private JsonKey() {}
 }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
@@ -182,7 +182,7 @@ public class UserExternalIdManagementActor extends BaseActor {
     map.remove(JsonKey.ORIGINAL_EXTERNAL_ID);
     map.remove(JsonKey.ORIGINAL_ID_TYPE);
     map.remove(JsonKey.ORIGINAL_PROVIDER);
-    map.remove(JsonKey.STATUS);
+    // map.remove(JsonKey.STATUS);
     cassandraOperation.deleteRecord(JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, map);
   }
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserExternalIdManagementActor.java
@@ -204,7 +204,7 @@ public class UserExternalIdManagementActor extends BaseActor {
     map.put(JsonKey.ID_TYPE, extIdsMap.get(JsonKey.ID_TYPE));
     map.put(JsonKey.ORIGINAL_ID_TYPE, extIdsMap.get(JsonKey.ORIGINAL_ID_TYPE));
     map.put(JsonKey.USER_ID, requestMap.get(JsonKey.USER_ID));
-    map.put(JsonKey.STATUS,extIdsMap.get(JsonKey.STATUS));
+    // map.put(JsonKey.STATUS,extIdsMap.get(JsonKey.STATUS));
     if (JsonKey.CREATE.equalsIgnoreCase(operation)) {
       map.put(JsonKey.CREATED_BY, requestMap.get(JsonKey.CREATED_BY));
       map.put(JsonKey.CREATED_ON, new Timestamp(Calendar.getInstance().getTime().getTime()));

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -43,6 +43,7 @@ import org.sunbird.kafka.client.KafkaClient;
 import org.sunbird.learner.actors.role.service.RoleService;
 import org.sunbird.learner.organisation.external.identity.service.OrgExternalService;
 import org.sunbird.learner.util.*;
+import org.sunbird.models.location.Location;
 import org.sunbird.models.organisation.Organisation;
 import org.sunbird.models.user.User;
 import org.sunbird.models.user.UserType;
@@ -177,7 +178,7 @@ public class UserManagementActor extends BaseActor {
   private void updateUser(Request actorMessage) {
     Util.initializeContext(actorMessage, TelemetryEnvKey.USER);
     actorMessage.toLower();
-    //Util.getUserProfileConfig(systemSettingActorRef);
+    // Util.getUserProfileConfig(systemSettingActorRef);
     String callerId = (String) actorMessage.getContext().get(JsonKey.CALLER_ID);
     boolean isPrivate = false;
     if (actorMessage.getContext().containsKey(JsonKey.PRIVATE)) {
@@ -203,13 +204,13 @@ public class UserManagementActor extends BaseActor {
     User user = mapper.convertValue(userMap, User.class);
     UserUtil.validateExternalIdsForUpdateUser(user, isCustodianOrgUser);
     userMap.put(JsonKey.EXTERNAL_IDS, user.getExternalIds());
+    updateLocationCodeToIds((List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS));
     UserUtil.validateUserPhoneEmailAndWebPages(user, JsonKey.UPDATE);
     // not allowing user to update the status,provider,userName
     removeFieldsFrmReq(userMap);
     // if we are updating email then need to update isEmailVerified flag inside keycloak
     UserUtil.checkEmailSameOrDiff(userMap, userDbRecord);
     convertValidatedLocationCodesToIDs(userMap);
-
     userMap.put(JsonKey.UPDATED_DATE, ProjectUtil.getFormattedDate());
     if (StringUtils.isBlank(callerId)) {
       userMap.put(JsonKey.UPDATED_BY, actorMessage.getContext().get(JsonKey.REQUESTED_BY));
@@ -280,6 +281,36 @@ public class UserManagementActor extends BaseActor {
             (String) userMap.get(JsonKey.USER_ID), TelemetryEnvKey.USER, JsonKey.UPDATE, null);
     TelemetryUtil.telemetryProcessingCall(
         userMap, targetObject, correlatedObject, actorMessage.getContext());
+  }
+
+  private void updateLocationCodeToIds(List<Map<String, String>> externalIds) {
+    List<String> locCodeLst = new ArrayList<>();
+    Map<String, String> locMap = new HashMap<>();
+    externalIds.forEach(
+        externalIdMap -> {
+          if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
+              || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
+            locCodeLst.add(externalIdMap.get(JsonKey.ID));
+          }
+        });
+    LocationClientImpl locationClient = new LocationClientImpl();
+    List<Location> locationIdList =
+        locationClient.getLocationByCodes(
+            getActorRef(LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()), locCodeLst);
+    if (locationIdList != null && !locationIdList.isEmpty()) {
+      externalIds.forEach(
+          externalIdMap -> {
+            if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
+                || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
+              locationIdList.forEach(
+                  location -> {
+                    if (location.getCode().equals(externalIdMap.get(JsonKey.ID))) {
+                      externalIdMap.put(JsonKey.ID, location.getId());
+                    }
+                  });
+            }
+          });
+    }
   }
 
   /**
@@ -566,7 +597,7 @@ public class UserManagementActor extends BaseActor {
     userMap.remove(JsonKey.ENC_EMAIL);
     userMap.remove(JsonKey.ENC_PHONE);
     actorMessage.getRequest().putAll(userMap);
-    //Util.getUserProfileConfig(systemSettingActorRef);
+    // Util.getUserProfileConfig(systemSettingActorRef);
     boolean isCustodianOrg = false;
     if (StringUtils.isBlank(callerId)) {
       userMap.put(JsonKey.CREATED_BY, actorMessage.getContext().get(JsonKey.REQUESTED_BY));

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -285,31 +285,32 @@ public class UserManagementActor extends BaseActor {
 
   private void updateLocationCodeToIds(List<Map<String, String>> externalIds) {
     List<String> locCodeLst = new ArrayList<>();
-    Map<String, String> locMap = new HashMap<>();
-    externalIds.forEach(
-        externalIdMap -> {
-          if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
-              || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
-            locCodeLst.add(externalIdMap.get(JsonKey.ID));
-          }
-        });
-    LocationClientImpl locationClient = new LocationClientImpl();
-    List<Location> locationIdList =
-        locationClient.getLocationByCodes(
-            getActorRef(LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()), locCodeLst);
-    if (locationIdList != null && !locationIdList.isEmpty()) {
+    if (CollectionUtils.isNotEmpty(externalIds)) {
       externalIds.forEach(
           externalIdMap -> {
             if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
                 || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
-              locationIdList.forEach(
-                  location -> {
-                    if (location.getCode().equals(externalIdMap.get(JsonKey.ID))) {
-                      externalIdMap.put(JsonKey.ID, location.getId());
-                    }
-                  });
+              locCodeLst.add(externalIdMap.get(JsonKey.ID));
             }
           });
+      LocationClientImpl locationClient = new LocationClientImpl();
+      List<Location> locationIdList =
+          locationClient.getLocationByCodes(
+              getActorRef(LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()), locCodeLst);
+      if (CollectionUtils.isNotEmpty(locationIdList)) {
+        externalIds.forEach(
+            externalIdMap -> {
+              if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
+                  || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
+                locationIdList.forEach(
+                    location -> {
+                      if (location.getCode().equals(externalIdMap.get(JsonKey.ID))) {
+                        externalIdMap.put(JsonKey.ID, location.getId());
+                      }
+                    });
+              }
+            });
+      }
     }
   }
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -298,17 +298,18 @@ public class UserManagementActor extends BaseActor {
           locationClient.getLocationByCodes(
               getActorRef(LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()), locCodeLst);
       if (CollectionUtils.isNotEmpty(locationIdList)) {
-        externalIds.forEach(
-            externalIdMap -> {
-              if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
-                  || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
-                locationIdList.forEach(
-                    location -> {
+        locationIdList.forEach(
+            location -> {
+              externalIds.forEach(
+                  externalIdMap -> {
+                    if (externalIdMap.containsValue(JsonKey.DECLARED_STATE)
+                        || externalIdMap.containsValue(JsonKey.DECLARED_DISTRICT)) {
                       if (location.getCode().equals(externalIdMap.get(JsonKey.ID))) {
                         externalIdMap.put(JsonKey.ID, location.getId());
+                        externalIdMap.put(JsonKey.ORIGINAL_EXTERNAL_ID, location.getId());
                       }
-                    });
-              }
+                    }
+                  });
             });
       }
     }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -314,16 +314,6 @@ public class UserProfileReadActor extends BaseActor {
                   if (StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_EXTERNAL_ID))
                       && StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_ID_TYPE))
                       && StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_PROVIDER))) {
-                    if (JsonKey.DECLARED_DISTRICT.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))
-                        || JsonKey.DECLARED_STATE.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))) {
-                      LocationClientImpl locationClient = new LocationClientImpl();
-                      Location location =
-                          locationClient.getLocationById(
-                              getActorRef(
-                                  LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()),
-                              s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
-                      s.put(JsonKey.ID, location.getCode());
-                    }
                     if (JsonKey.DECLARED_EMAIL.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))
                         || JsonKey.DECLARED_PHONE.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))) {
 
@@ -331,6 +321,14 @@ public class UserProfileReadActor extends BaseActor {
                           UserUtil.getDecryptedData(s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
                       s.put(JsonKey.ID, decrytpedOriginalExternalId);
 
+                    } else if (JsonKey.DECLARED_DISTRICT.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))
+                        || JsonKey.DECLARED_STATE.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))) {
+                      LocationClientImpl locationClient = new LocationClientImpl();
+                      Location location =
+                          locationClient.getLocationById(
+                              getActorRef(LocationActorOperation.SEARCH_LOCATION.getValue()),
+                              s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
+                      s.put(JsonKey.ID, location.getCode());
                     } else {
                       s.put(JsonKey.ID, s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
                     }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.sunbird.actor.core.BaseActor;
 import org.sunbird.actor.router.ActorConfig;
+import org.sunbird.actorutil.location.impl.LocationClientImpl;
 import org.sunbird.actorutil.systemsettings.SystemSettingClient;
 import org.sunbird.actorutil.systemsettings.impl.SystemSettingClientImpl;
 import org.sunbird.cassandra.CassandraOperation;
@@ -36,6 +37,7 @@ import org.sunbird.helper.ServiceFactory;
 import org.sunbird.learner.util.DataCacheHandler;
 import org.sunbird.learner.util.UserUtility;
 import org.sunbird.learner.util.Util;
+import org.sunbird.models.location.Location;
 import org.sunbird.models.user.User;
 import org.sunbird.services.sso.SSOManager;
 import org.sunbird.services.sso.SSOServiceFactory;
@@ -312,6 +314,16 @@ public class UserProfileReadActor extends BaseActor {
                   if (StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_EXTERNAL_ID))
                       && StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_ID_TYPE))
                       && StringUtils.isNotBlank(s.get(JsonKey.ORIGINAL_PROVIDER))) {
+                    if (JsonKey.DECLARED_DISTRICT.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))
+                        || JsonKey.DECLARED_STATE.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))) {
+                      LocationClientImpl locationClient = new LocationClientImpl();
+                      Location location =
+                          locationClient.getLocationById(
+                              getActorRef(
+                                  LocationActorOperation.GET_RELATED_LOCATION_IDS.getValue()),
+                              s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
+                      s.put(JsonKey.ID, location.getCode());
+                    }
                     if (JsonKey.DECLARED_EMAIL.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))
                         || JsonKey.DECLARED_PHONE.equals(s.get(JsonKey.ORIGINAL_ID_TYPE))) {
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -663,7 +663,7 @@ public class UserUtil {
     if (CollectionUtils.isNotEmpty(user.getExternalIds())) {
       validateUserExternalIds(user);
     }
-    if(CollectionUtils.isNotEmpty(user.getExternalIds())){
+    if (CollectionUtils.isNotEmpty(user.getExternalIds())) {
       updateExternalIdsStatus(user.getExternalIds());
     }
   }
@@ -686,12 +686,11 @@ public class UserUtil {
     }
   }
 
-  private static void updateExternalIdsStatus(
-          List<Map<String, String>> externalIds) {
+  private static void updateExternalIdsStatus(List<Map<String, String>> externalIds) {
     externalIds.forEach(
-            externalIdMap -> {
-              externalIdMap.put(JsonKey.STATUS, JsonKey.SUBMITTED);
-            });
+        externalIdMap -> {
+          externalIdMap.put(JsonKey.STATUS, JsonKey.PENDING);
+        });
   }
 
   private static Optional<Map<String, String>> checkExternalID(

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -689,7 +689,8 @@ public class UserUtil {
   private static void updateExternalIdsStatus(List<Map<String, String>> externalIds) {
     externalIds.forEach(
         externalIdMap -> {
-          externalIdMap.put(JsonKey.STATUS, JsonKey.PENDING);
+          // Needed in 3.2
+          // externalIdMap.put(JsonKey.STATUS, JsonKey.PENDING);
         });
   }
 


### PR DESCRIPTION
Previously we are saving location codes to usr_external_identity table, now in order make symmetric across application we are saving location ids.
Changes done to update and read api accordingly, so that portal won't get affected.
Because of this user self-declared report also affected.
removing status column updation on every declared-field value