### PR TITLE
SB-19871 USER_DATA_ENCRYPTION_ERROR in read api

### DIFF
--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/userencryption.properties
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/userencryption.properties
@@ -1,6 +1,6 @@
-userkey.encryption=email,phone,userName,location,loginId,prevUsedEmail,prevUsedPhone,recoveryEmail,recoveryPhone
+userkey.encryption=email,phone,userName,loginId,prevUsedEmail,prevUsedPhone,recoveryEmail,recoveryPhone
 addresskey.encryption=addressLine1,addressLine2,city,state,country,zipcode,userId,updatedBy,createdBy
-userkey.decryption=encEmail,encPhone,userName,location,loginId,email,phone,prevUsedEmail,prevUsedPhone,recoveryEmail,recoveryPhone
+userkey.decryption=encEmail,encPhone,userName,loginId,email,phone,prevUsedEmail,prevUsedPhone,recoveryEmail,recoveryPhone
 userkey.masked=email,phone,recoveryEmail,recoveryPhone,prevUsedPhone,recoveryEmail,prevUsedEmail
 userkey.phonetypeattributes=phone,recoveryPhone,prevUsedPhone
 userkey.emailtypeattributes=email,recoveryEmail,prevUsedEmail

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -328,7 +328,11 @@ public class UserProfileReadActor extends BaseActor {
                           locationClient.getLocationById(
                               getActorRef(LocationActorOperation.SEARCH_LOCATION.getValue()),
                               s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
-                      s.put(JsonKey.ID, (location == null?  s.get(JsonKey.ORIGINAL_EXTERNAL_ID) :  location.getCode());
+                      s.put(
+                          JsonKey.ID,
+                          (location == null
+                              ? s.get(JsonKey.ORIGINAL_EXTERNAL_ID)
+                              : location.getCode()));
                     } else {
                       s.put(JsonKey.ID, s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
                     }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -328,7 +328,7 @@ public class UserProfileReadActor extends BaseActor {
                           locationClient.getLocationById(
                               getActorRef(LocationActorOperation.SEARCH_LOCATION.getValue()),
                               s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
-                      s.put(JsonKey.ID, location.getCode());
+                      s.put(JsonKey.ID, (location == null?  s.get(JsonKey.ORIGINAL_EXTERNAL_ID) :  location.getCode());
                     } else {
                       s.put(JsonKey.ID, s.get(JsonKey.ORIGINAL_EXTERNAL_ID));
                     }


### PR DESCRIPTION
In Read api for old data, if the location is not found with location-id search call application is throwing "USER_DATA_ENCRYPTION_ERROR" since the whole logic is encapsulated with Data-encryption try-catch.

Old data will have location code saved in the usr_external_identity, so location details can't be searched with location-code.