### PR TITLE
SC-1883: Enhance create tenant preference api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           paths: ~/.m2
       - run:
          name: Analyze on SonarCloud
-         command: mvn verify -DskipTests sonar:sonar -Dsonar.projectKey=project-sunbird_sunbird-lms-service -Dsonar.organization=project-sunbird -Dsonar.host.url=https://sonarcloud.io -Dsonar.coverage.exclusions=**/models/** -Dsonar.coverage.jacoco.xmlReportPaths=/home/circleci/project/service/target/site/jacoco/jacoco.xml,/home/circleci/project/actors/sunbird-lms-mw/actors/user/target/site/jacoco/jacoco.xml
+         command: mvn verify -DskipTests sonar:sonar -Dsonar.projectKey=project-sunbird_sunbird-lms-service -Dsonar.organization=project-sunbird -Dsonar.host.url=https://sonarcloud.io -Dsonar.coverage.exclusions=**/models/** -Dsonar.coverage.jacoco.xmlReportPaths=/home/circleci/project/service/target/site/jacoco/jacoco.xml,/home/circleci/project/actors/sunbird-lms-mw/actors/user/target/site/jacoco/jacoco.xml,/home/circleci/project/actors/sunbird-lms-mw/actors/common/target/site/jacoco/jacoco.xml
 
 
 workflows:

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tenantpreference/TenantPreferenceManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tenantpreference/TenantPreferenceManagementActor.java
@@ -1,8 +1,10 @@
 package org.sunbird.learner.actors.tenantpreference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -181,6 +183,8 @@ public class TenantPreferenceManagementActor extends BaseActor {
       dbMap.put(JsonKey.ORG_ID, orgId);
       dbMap.put(JsonKey.KEY, key);
       dbMap.put(JsonKey.DATA, serialize(req.get(JsonKey.DATA)));
+      dbMap.put(JsonKey.CREATED_BY, actorMessage.getContext().get(JsonKey.REQUESTED_BY));
+      dbMap.put(JsonKey.CREATED_ON, new Timestamp(Calendar.getInstance().getTimeInMillis()));
     } catch (Exception e) {
       ProjectLogger.log("exception while adding preferences " + e.getMessage(), LoggerEnum.DEBUG);
     }

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/util/Util.java
@@ -167,6 +167,8 @@ public final class Util {
         getDbInfoObject(KEY_SPACE_NAME, "user_badge_assertion"));
     dbInfoMap.put(JsonKey.USER_CERT, getDbInfoObject(KEY_SPACE_NAME, JsonKey.USER_CERT));
     dbInfoMap.put(JsonKey.USER_FEED_DB, getDbInfoObject(KEY_SPACE_NAME, JsonKey.USER_FEED_DB));
+    dbInfoMap.put(
+        JsonKey.TENANT_PREFERENCE_V2, getDbInfoObject(KEY_SPACE_NAME, "tenant_preference_v2"));
   }
 
   /**
@@ -522,7 +524,7 @@ public final class Util {
           "Util:registerChannel: Channel registration request data = " + reqString,
           LoggerEnum.DEBUG.name());
       regStatus =
-        HttpClientUtil.post(
+          HttpClientUtil.post(
               (ekStepBaseUrl
                   + PropertiesCache.getInstance().getProperty(JsonKey.EKSTEP_CHANNEL_REG_API_URL)),
               reqString,
@@ -580,7 +582,7 @@ public final class Util {
       reqString = mapper.writeValueAsString(map);
 
       regStatus =
-        HttpClientUtil.patch(
+          HttpClientUtil.patch(
               (ekStepBaseUrl
                       + PropertiesCache.getInstance()
                           .getProperty(JsonKey.EKSTEP_CHANNEL_UPDATE_API_URL))

--- a/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/tenantpreference/TenantPreferenceManagementActorTest.java
+++ b/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/tenantpreference/TenantPreferenceManagementActorTest.java
@@ -93,20 +93,17 @@ public class TenantPreferenceManagementActorTest {
     TestKit probe = new TestKit(system);
     ActorRef subject = system.actorOf(props);
     Request actorMessage = new Request();
-    List<Map<String, Object>> reqList = new ArrayList<>();
-
     Map<String, Object> map = new HashMap<>();
     map.put(JsonKey.KEY, "anyKey");
-    reqList.add(map);
-
-    actorMessage.getRequest().put(JsonKey.TENANT_PREFERENCE, reqList);
-    actorMessage.getRequest().put(JsonKey.ROOT_ORG_ID, orgId);
-    actorMessage.getRequest().put(JsonKey.REQUESTED_BY, USER_ID);
+    map.put(JsonKey.DATA, new HashMap<>());
+    map.put(JsonKey.ORG_ID, orgId);
+    actorMessage.setRequest(map);
     actorMessage.setOperation(ActorOperations.CREATE_TENANT_PREFERENCE.getValue());
 
     subject.tell(actorMessage, probe.getRef());
-    Response res = probe.expectMsgClass(duration("10 second"), Response.class);
-    Assert.assertTrue(null != res.get(JsonKey.RESPONSE));
+    ProjectCommonException exception =
+        probe.expectMsgClass(duration("10 second"), ProjectCommonException.class);
+    Assert.assertTrue(null != exception);
   }
 
   @Test
@@ -115,62 +112,14 @@ public class TenantPreferenceManagementActorTest {
     TestKit probe = new TestKit(system);
     ActorRef subject = system.actorOf(props);
     Request actorMessage = new Request();
-    List<Map<String, Object>> reqList = new ArrayList<>();
-
     Map<String, Object> map = new HashMap<>();
-    map.put(JsonKey.KEY, "differentKey");
-    reqList.add(map);
-
-    actorMessage.getRequest().put(JsonKey.TENANT_PREFERENCE, reqList);
-    actorMessage.getRequest().put(JsonKey.ROOT_ORG_ID, orgId);
-    actorMessage.getRequest().put(JsonKey.REQUESTED_BY, USER_ID);
+    map.put(JsonKey.KEY, "teacher_declaration");
+    map.put(JsonKey.ORG_ID, orgId);
+    actorMessage.setRequest(map);
     actorMessage.setOperation(ActorOperations.CREATE_TENANT_PREFERENCE.getValue());
-
     subject.tell(actorMessage, probe.getRef());
     Response res = probe.expectMsgClass(duration("10 second"), Response.class);
     Assert.assertTrue(null != res.get(JsonKey.RESPONSE));
-  }
-
-  @Test
-  public void testCreateTanentPreferenceFailureWithInvalidOrgId() {
-
-    TestKit probe = new TestKit(system);
-    ActorRef subject = system.actorOf(props);
-    Request actorMessage = new Request();
-    List<Map<String, Object>> reqList = new ArrayList<>();
-
-    Map<String, Object> map = new HashMap<>();
-    map.put(JsonKey.ROLE, "admin");
-    reqList.add(map);
-
-    actorMessage.getRequest().put(JsonKey.TENANT_PREFERENCE, reqList);
-    actorMessage.getRequest().put(JsonKey.ROOT_ORG_ID, "");
-    actorMessage.getRequest().put(JsonKey.REQUESTED_BY, USER_ID);
-    actorMessage.setOperation(ActorOperations.CREATE_TENANT_PREFERENCE.getValue());
-
-    subject.tell(actorMessage, probe.getRef());
-    ProjectCommonException exc =
-        probe.expectMsgClass(duration("10 second"), ProjectCommonException.class);
-    Assert.assertTrue(null != exc);
-  }
-
-  @Test
-  public void testCreateTanentPreferenceWithInvalidReqData() {
-
-    TestKit probe = new TestKit(system);
-    ActorRef subject = system.actorOf(props);
-    Request actorMessage = new Request();
-    List<Map<String, Object>> reqList = new ArrayList<>();
-
-    actorMessage.getRequest().put(JsonKey.TENANT_PREFERENCE, reqList);
-    actorMessage.getRequest().put(JsonKey.ROOT_ORG_ID, orgId);
-    actorMessage.getRequest().put(JsonKey.REQUESTED_BY, USER_ID);
-    actorMessage.setOperation(ActorOperations.CREATE_TENANT_PREFERENCE.getValue());
-
-    subject.tell(actorMessage, probe.getRef());
-    ProjectCommonException exc =
-        probe.expectMsgClass(duration("10 second"), ProjectCommonException.class);
-    Assert.assertTrue(null != exc);
   }
 
   @Test
@@ -352,9 +301,10 @@ public class TenantPreferenceManagementActorTest {
 
   private static Response cassandraGetRecordByProperty() {
     Response response = new Response();
-    List list = new ArrayList();
+    List<Map<String, Object>> list = new ArrayList();
     Map<String, Object> map = new HashMap<>();
     map.put(JsonKey.KEY, "anyKey");
+    map.put(JsonKey.ORG_ID, orgId);
     list.add(map);
     response.put(JsonKey.RESPONSE, list);
     return response;

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1063,6 +1063,7 @@ public final class JsonKey {
   public static final String ERROR_TYPE = "errorType";
   public static final String DECLARATIONS = "declarations";
   public static final String PERSONA = "persona";
+  public static final String TENANT_PREFERENCE_V2 = "tenantPreferenceV2";
 
   private JsonKey() {}
 }

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
@@ -873,6 +873,9 @@ public enum ResponseCode {
       ResponseMessage.Key.NO_EMAIL_PHONE_ASSOCIATED,
       ResponseMessage.Message.NO_EMAIL_PHONE_ASSOCIATED),
   invalidCaptcha(ResponseMessage.Key.INVALID_CAPTCHA, ResponseMessage.Message.INVALID_CAPTCHA),
+  preferenceAlreadyExists(
+      ResponseMessage.Key.PREFERENCE_ALREADY_EXIST,
+      ResponseMessage.Message.PREFERENCE_ALREADY_EXIST),
   OK(200),
   CLIENT_ERROR(400),
   SERVER_ERROR(500),

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
@@ -479,6 +479,7 @@ public interface ResponseMessage {
     String DATA_ENCRYPTION_ERROR = "Error in encrypting the data";
     String NO_EMAIL_PHONE_ASSOCIATED = "No {0} associated with the given user.";
     String INVALID_CAPTCHA = "Captcha is invalid";
+    String PREFERENCE_ALREADY_EXIST = "preference {0} already exits in the org {1}";
   }
 
   interface Key {
@@ -882,5 +883,6 @@ public interface ResponseMessage {
     String DATA_ENCRYPTION_ERROR = "DATA_ENCRYPTION_ERROR";
     String NO_EMAIL_PHONE_ASSOCIATED = "NO_EMAIL_PHONE_ASSOCIATED";
     String INVALID_CAPTCHA = "INVALID_CAPTCHA";
+    String PREFERENCE_ALREADY_EXIST = "PREFERENCE_ALREADY_EXIST";
   }
 }

--- a/service/app/controllers/tenantpreference/TenantPreferenceController.java
+++ b/service/app/controllers/tenantpreference/TenantPreferenceController.java
@@ -17,20 +17,18 @@ import play.mvc.Result;
 public class TenantPreferenceController extends BaseController {
 
   public CompletionStage<Result> createTenantPreference(Http.Request httpRequest) {
-    try {
-      JsonNode requestData = httpRequest.body().asJson();
-      ProjectLogger.log("Create tenant preferences: " + requestData, LoggerEnum.INFO.name());
-      Request reqObj = (Request) mapper.RequestMapper.mapRequest(requestData, Request.class);
-      reqObj.setOperation(ActorOperations.CREATE_TENANT_PREFERENCE.getValue());
-      reqObj.setRequestId(httpRequest.flash().get(JsonKey.REQUEST_ID));
-      reqObj.setEnv(getEnvironment());
-      Map<String, Object> innerMap = reqObj.getRequest();
-      innerMap.put(JsonKey.REQUESTED_BY, httpRequest.flash().get(JsonKey.USER_ID));
-      reqObj.setRequest(innerMap);
-      return actorResponseHandler(getActorRef(), reqObj, timeout, null, httpRequest);
-    } catch (Exception e) {
-      return CompletableFuture.completedFuture(createCommonExceptionResponse(e, httpRequest));
-    }
+    return handleRequest(
+        ActorOperations.CREATE_TENANT_PREFERENCE.getValue(),
+        httpRequest.body().asJson(),
+        req -> {
+          Request request = (Request) req;
+          new TenantPreferenceValidator().validateCreatePreferenceRequest(request);
+          return null;
+        },
+        null,
+        null,
+        true,
+        httpRequest);
   }
 
   public CompletionStage<Result> updateTenantPreference(Http.Request httpRequest) {

--- a/service/app/controllers/tenantpreference/TenantPreferenceValidator.java
+++ b/service/app/controllers/tenantpreference/TenantPreferenceValidator.java
@@ -1,0 +1,82 @@
+package controllers.tenantpreference;
+
+import com.google.common.collect.Lists;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.sunbird.common.exception.ProjectCommonException;
+import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.request.BaseRequestValidator;
+import org.sunbird.common.request.Request;
+import org.sunbird.common.responsecode.ResponseCode;
+
+public class TenantPreferenceValidator extends BaseRequestValidator {
+
+  public void validateCreatePreferenceRequest(Request request) {
+    validateMandatoryParamsWithType(
+        request.getRequest(),
+        Lists.newArrayList(JsonKey.ORG_ID, JsonKey.KEY),
+        String.class,
+        true,
+        JsonKey.REQUEST);
+    validateMandatoryParamsWithType(
+        request.getRequest(), Lists.newArrayList(JsonKey.DATA), Map.class, true, JsonKey.REQUEST);
+  }
+
+  public static void validateMandatoryParamsWithType(
+      Map<String, Object> reqMap,
+      List<String> mandatoryParamsList,
+      Class<?> type,
+      boolean validatePresence,
+      String parentKey) {
+    for (String param : mandatoryParamsList) {
+      if (!reqMap.containsKey(param)) {
+        throw new ProjectCommonException(
+            ResponseCode.mandatoryParamsMissing.getErrorCode(),
+            MessageFormat.format(
+                ResponseCode.mandatoryParamsMissing.getErrorMessage(), parentKey + "." + param),
+            ResponseCode.CLIENT_ERROR.getResponseCode());
+      }
+
+      if (!(isInstanceOf(reqMap.get(param).getClass(), type))) {
+        throw new ProjectCommonException(
+            ResponseCode.dataTypeError.getErrorCode(),
+            MessageFormat.format(
+                ResponseCode.dataTypeError.getErrorMessage(),
+                parentKey + "." + param,
+                type.getName()),
+            ResponseCode.CLIENT_ERROR.getResponseCode());
+      }
+      if (validatePresence) {
+        validatePresence(param, reqMap.get(param), type, parentKey);
+      }
+    }
+  }
+
+  private static void validatePresence(String key, Object value, Class<?> type, String parentKey) {
+    if (type == String.class) {
+      if (StringUtils.isBlank((String) value)) {
+        throw new ProjectCommonException(
+            ResponseCode.mandatoryParamsMissing.getErrorCode(),
+            MessageFormat.format(
+                ResponseCode.mandatoryParamsMissing.getErrorMessage(), parentKey + "." + key),
+            ResponseCode.CLIENT_ERROR.getResponseCode());
+      }
+    } else if (type == Map.class) {
+      Map<String, Object> map = (Map<String, Object>) value;
+      if (MapUtils.isEmpty(map)) {
+        throw new ProjectCommonException(
+            ResponseCode.mandatoryParamsMissing.getErrorCode(),
+            MessageFormat.format(
+                ResponseCode.mandatoryParamsMissing.getErrorMessage(), parentKey + "." + key),
+            ResponseCode.CLIENT_ERROR.getResponseCode());
+      }
+    }
+  }
+
+  private static boolean isInstanceOf(Class objClass, Class targetClass) {
+    return targetClass.isAssignableFrom(objClass);
+  }
+}

--- a/service/app/util/RequestInterceptor.java
+++ b/service/app/util/RequestInterceptor.java
@@ -69,7 +69,6 @@ public class RequestInterceptor {
     apiHeaderIgnoreMap.put("/v1/user/getuser", var);
     apiHeaderIgnoreMap.put("/v1/notification/audience", var);
     apiHeaderIgnoreMap.put("/v1/org/preferences/read", var);
-    apiHeaderIgnoreMap.put("/v1/org/preferences/create", var);
     apiHeaderIgnoreMap.put("/v1/org/preferences/update", var);
     apiHeaderIgnoreMap.put("/v1/telemetry", var);
     // making badging api's as public access

--- a/service/test/controllers/tenantpreference/TenantPreferenceControllerTest.java
+++ b/service/test/controllers/tenantpreference/TenantPreferenceControllerTest.java
@@ -1,0 +1,109 @@
+package controllers.tenantpreference;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import controllers.BaseApplicationTest;
+import controllers.DummyActor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import modules.OnRequestHandler;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.models.util.ProjectLogger;
+import org.sunbird.common.request.HeaderParam;
+import org.sunbird.common.responsecode.ResponseCode;
+import play.libs.Json;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.test.Helpers;
+
+@PrepareForTest(OnRequestHandler.class)
+public class TenantPreferenceControllerTest extends BaseApplicationTest {
+
+  public static Map<String, List<String>> headerMap;
+
+  @Before
+  public void before() {
+    setup(DummyActor.class);
+    headerMap = new HashMap<>();
+    headerMap.put(HeaderParam.X_Consumer_ID.getName(), Arrays.asList("Some consumer ID"));
+    headerMap.put(HeaderParam.X_Device_ID.getName(), Arrays.asList("Some device ID"));
+    headerMap.put(
+        HeaderParam.X_Authenticated_Userid.getName(), Arrays.asList("Some authenticated user ID"));
+    headerMap.put(JsonKey.MESSAGE_ID, Arrays.asList("Some message ID"));
+    headerMap.put(HeaderParam.X_APP_ID.getName(), Arrays.asList("Some app Id"));
+  }
+
+  @Test
+  public void testCreateTenantPreferenceSuccess() {
+    Map<String, Object> requestMap = new HashMap<>();
+    Map<String, Object> innerMap = new HashMap<>();
+    innerMap.put(JsonKey.KEY, "teacher");
+    innerMap.put(JsonKey.ORG_ID, "organisationId");
+    Map<String, Object> map = new HashMap<>();
+    map.put(JsonKey.FIELDS, new ArrayList<>());
+    innerMap.put(JsonKey.DATA, map);
+    requestMap.put(JsonKey.REQUEST, innerMap);
+    Result result = performTest("/v1/org/preferences/create", "POST", requestMap);
+    assertEquals(getResponseCode(result), ResponseCode.success.getErrorCode().toLowerCase());
+  }
+
+  @Test
+  public void testCreatePreferenceWithMandatoryParamOrgId() {
+    Map<String, Object> requestMap = new HashMap<>();
+    Map<String, Object> innerMap = new HashMap<>();
+    innerMap.put(JsonKey.KEY, "teacher");
+    requestMap.put(JsonKey.REQUEST, innerMap);
+    Result result = performTest("/v1/org/preferences/create", "POST", requestMap);
+    assertEquals(getResponseCode(result), ResponseCode.mandatoryParamsMissing.getErrorCode());
+  }
+
+  @Test
+  public void testCreateTenantPreferenceWithDataTypeError() {
+    Map<String, Object> requestMap = new HashMap<>();
+    Map<String, Object> innerMap = new HashMap<>();
+    innerMap.put(JsonKey.KEY, "teacher");
+    innerMap.put(JsonKey.ORG_ID, "organisationId");
+    innerMap.put(JsonKey.DATA, "data");
+    requestMap.put(JsonKey.REQUEST, innerMap);
+    Result result = performTest("/v1/org/preferences/create", "POST", requestMap);
+    assertEquals(getResponseCode(result), ResponseCode.dataTypeError.getErrorCode());
+  }
+
+  public String mapToJson(Map map) {
+    ObjectMapper mapperObj = new ObjectMapper();
+    String jsonResp = "";
+
+    if (map != null) {
+      try {
+        jsonResp = mapperObj.writeValueAsString(map);
+      } catch (IOException e) {
+        ProjectLogger.log(e.getMessage(), e);
+      }
+    }
+    return jsonResp;
+  }
+
+  public Result performTest(String url, String method, Map map) {
+    String data = mapToJson(map);
+    Http.RequestBuilder req;
+    if (StringUtils.isNotBlank(data)) {
+      JsonNode json = Json.parse(data);
+      req = new Http.RequestBuilder().bodyJson(json).uri(url).method(method);
+    } else {
+      req = new Http.RequestBuilder().uri(url).method(method);
+    }
+    // req.headers(new Http.Headers(headerMap));
+    Result result = Helpers.route(application, req);
+    return result;
+  }
+}


### PR DESCRIPTION
Api endpoint: **v1/org/preferences/create**

Request :  `{
    "request": {
        "orgId": "", //mandatory
        "key": "",//mandatory
        "data": {}//mandatory
    }
}`

Response:  

-  **success response**`{
    "id": "api.org.preferences.create",
    "ver": "v1",
    "ts": "2020-08-04 18:40:47:142+0530",
    "params": {
        "resmsgid": null,
        "msgid": "52b2e453-09bb-4cf3-b5a5-fa3dda1335b5",
        "err": null,
        "status": "success",
        "errmsg": null
    },
    "responseCode": "OK",
    "result": {
        "response": "SUCCESS",
        "orgId": "2323",
        "key": "teacher"
    }
}`

- **Missing param** `{
    "id": "api.org.preferences.create",
    "ver": "v1",
    "ts": "2020-08-04 18:40:06:376+0530",
    "params": {
        "resmsgid": null,
        "msgid": "d09558a0-2a4b-4023-8421-5a305b79ca06",
        "err": "MANDATORY_PARAMETER_MISSING",
        "status": "MANDATORY_PARAMETER_MISSING",
        "errmsg": "Mandatory parameter request.data is missing."
    },
    "responseCode": "CLIENT_ERROR",
    "result": {}
}`

- **data type error**`{
    "id": "api.org.preferences.create",
    "ver": "v1",
    "ts": "2020-08-04 18:39:26:727+0530",
    "params": {
        "resmsgid": null,
        "msgid": "0867d734-3644-40d8-923b-34c695974a91",
        "err": "DATA_TYPE_ERROR",
        "status": "DATA_TYPE_ERROR",
        "errmsg": "Data type of request.key should be java.lang.String."
    },
    "responseCode": "CLIENT_ERROR",
    "result": {}
}`

- **preference already exists** `{
    "id": "api.org.preferences.create",
    "ver": "v1",
    "ts": "2020-08-04 16:31:59:417+0530",
    "params": {
        "resmsgid": null,
        "msgid": "73fd02a8-5cee-4008-9fdb-1a54ce2eeb98",
        "err": "PREFERENCE_ALREADY_EXIST",
        "status": "PREFERENCE_ALREADY_EXIST",
        "errmsg": "preference 2343 already exits in the org 2323"
    },
    "responseCode": "CLIENT_ERROR",
    "result": {}
}`