### PR TITLE
SB-20052 update api fix

### DIFF
--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -351,15 +351,15 @@ public class UserManagementActor extends BaseActor {
       Set<String> providerSet = new HashSet<>();
       if (StringUtils.isNotBlank((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER))) {
         providerSet.add((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER));
-      } else {
-        List<Map<String, String>> extList =
-            (List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS);
-        if (CollectionUtils.isNotEmpty(extList)) {
-          for (Map<String, String> extId : extList) {
-            providerSet.add(extId.get(JsonKey.PROVIDER));
-          }
+      }
+      List<Map<String, String>> extList =
+          (List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS);
+      if (CollectionUtils.isNotEmpty(extList)) {
+        for (Map<String, String> extId : extList) {
+          providerSet.add(extId.get(JsonKey.PROVIDER));
         }
       }
+
       Map<String, String> orgProviderMap =
           UserUtil.fetchOrgIdByProvider(new ArrayList<String>(providerSet));
       if (StringUtils.isNotBlank((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER))) {

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -264,10 +264,12 @@ public class UserUtil {
       String provider = (String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER);
       String idType = (String) userMap.get(JsonKey.EXTERNAL_ID_TYPE);
       Map<String, String> providerOrgMap = new HashMap<>();
-      if (StringUtils.isNotBlank(provider)) {
+      if (StringUtils.isNotBlank(provider)
+          && StringUtils.isNotBlank(extId)
+          && StringUtils.isNotBlank(idType)) {
         providerOrgMap = fetchOrgIdByProvider(Arrays.asList(provider));
+        userId = userExternalIdentityService.getUser(extId, providerOrgMap.get(provider), idType);
       }
-      userId = userExternalIdentityService.getUser(extId, providerOrgMap.get(provider), idType);
     }
     return userId;
   }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -245,6 +245,7 @@ public class UserUtil {
   }
 
   public static String getUserIdFromExternalId(Map<String, Object> userMap) {
+
     String extId = (String) userMap.get(JsonKey.EXTERNAL_ID);
     String provider = (String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER);
     String idType = (String) userMap.get(JsonKey.EXTERNAL_ID_TYPE);
@@ -252,11 +253,23 @@ public class UserUtil {
   }
 
   public static String getUserId(Map<String, Object> userMap) {
-    String extId = (String) userMap.get(JsonKey.EXTERNAL_ID);
-    String provider = (String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER);
-    String idType = (String) userMap.get(JsonKey.EXTERNAL_ID_TYPE);
-    Map<String, String> providerOrgMap = fetchOrgIdByProvider(Arrays.asList(provider));
-    return userExternalIdentityService.getUser(extId, providerOrgMap.get(provider), idType);
+    String userId;
+    if (null != userMap.get(JsonKey.USER_ID)) {
+      userId = (String) userMap.get(JsonKey.USER_ID);
+    } else {
+      userId = (String) userMap.get(JsonKey.ID);
+    }
+    if (StringUtils.isBlank(userId)) {
+      String extId = (String) userMap.get(JsonKey.EXTERNAL_ID);
+      String provider = (String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER);
+      String idType = (String) userMap.get(JsonKey.EXTERNAL_ID_TYPE);
+      Map<String, String> providerOrgMap = new HashMap<>();
+      if (StringUtils.isNotBlank(provider)) {
+        providerOrgMap = fetchOrgIdByProvider(Arrays.asList(provider));
+      }
+      userId = userExternalIdentityService.getUser(extId, providerOrgMap.get(provider), idType);
+    }
+    return userId;
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Update api is failing during valid userId operation due to null pointer exception
getUserId is a common function, hence it should get the userId from request message during validation if not found then only check userExternalId service to get it through ext,provider,idtype