### PR TITLE
SB-19287 Add explicit logs

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
@@ -45,7 +45,7 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
   public void onReceive(Request request) throws Throwable {
     String env = null;
     String operation = request.getOperation();
-    ProjectLogger.log("OnReceive Upload csv processing {}", operation, LoggerEnum.INFO.name());
+    ProjectLogger.log("OnReceive Upload csv processing " + operation, LoggerEnum.INFO.name());
     if (operation.equals("userBulkSelfDeclared")) {
       env = "SelfDeclaredUserUpload";
     } else {

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
@@ -45,6 +45,7 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
   public void onReceive(Request request) throws Throwable {
     String env = null;
     String operation = request.getOperation();
+    ProjectLogger.log("OnReceive Upload csv processing {}", operation, LoggerEnum.INFO.name());
     if (operation.equals("userBulkSelfDeclared")) {
       env = "SelfDeclaredUserUpload";
     } else {

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/datasecurity/impl/DefaultDecryptionServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/datasecurity/impl/DefaultDecryptionServiceImpl.java
@@ -106,7 +106,7 @@ public class DefaultDecryptionServiceImpl implements DecryptionService {
       return dValue;
     } catch (Exception ex) {
       ProjectLogger.log(
-          "DefaultDecryptionServiceImpl:decrypt:value {}", value, LoggerEnum.INFO.name());
+          "DefaultDecryptionServiceImpl:decrypt:value " + value, LoggerEnum.INFO.name());
       ProjectLogger.log(
           "DefaultDecryptionServiceImpl:decrypt: Exception occurred with error message = "
               + ex.getMessage(),

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/datasecurity/impl/DefaultDecryptionServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/datasecurity/impl/DefaultDecryptionServiceImpl.java
@@ -106,6 +106,8 @@ public class DefaultDecryptionServiceImpl implements DecryptionService {
       return dValue;
     } catch (Exception ex) {
       ProjectLogger.log(
+          "DefaultDecryptionServiceImpl:decrypt:value {}", value, LoggerEnum.INFO.name());
+      ProjectLogger.log(
           "DefaultDecryptionServiceImpl:decrypt: Exception occurred with error message = "
               + ex.getMessage(),
           LoggerEnum.ERROR.name());

--- a/service/app/controllers/bulkapimanagement/BaseBulkUploadController.java
+++ b/service/app/controllers/bulkapimanagement/BaseBulkUploadController.java
@@ -46,7 +46,7 @@ public class BaseBulkUploadController extends BaseController {
   protected org.sunbird.common.request.Request createAndInitBulkRequest(
       String operation, String objectType, Boolean validateFileZize, Http.Request httpRequest)
       throws IOException {
-    ProjectLogger.log("API call for operation : {}", operation, LoggerEnum.INFO.name());
+    ProjectLogger.log("API call for operation : " + operation, LoggerEnum.INFO.name());
     org.sunbird.common.request.Request reqObj = new org.sunbird.common.request.Request();
     Map<String, Object> map = new HashMap<>();
     byte[] byteArray = null;

--- a/service/app/controllers/bulkapimanagement/BaseBulkUploadController.java
+++ b/service/app/controllers/bulkapimanagement/BaseBulkUploadController.java
@@ -15,6 +15,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.models.util.LoggerEnum;
 import org.sunbird.common.models.util.ProjectLogger;
 import org.sunbird.common.models.util.ProjectUtil;
 import org.sunbird.common.responsecode.ResponseCode;
@@ -45,7 +46,7 @@ public class BaseBulkUploadController extends BaseController {
   protected org.sunbird.common.request.Request createAndInitBulkRequest(
       String operation, String objectType, Boolean validateFileZize, Http.Request httpRequest)
       throws IOException {
-    ProjectLogger.log("API call for operation : " + operation);
+    ProjectLogger.log("API call for operation : {}", operation, LoggerEnum.INFO.name());
     org.sunbird.common.request.Request reqObj = new org.sunbird.common.request.Request();
     Map<String, Object> map = new HashMap<>();
     byte[] byteArray = null;
@@ -53,6 +54,7 @@ public class BaseBulkUploadController extends BaseController {
     Map<String, String[]> formUrlEncodeddata = httpRequest.body().asFormUrlEncoded();
     JsonNode requestData = httpRequest.body().asJson();
     if (body != null) {
+      ProjectLogger.log("Data sent as body", LoggerEnum.INFO.name());
       Map<String, String[]> data = body.asFormUrlEncoded();
       for (Entry<String, String[]> entry : data.entrySet()) {
         map.put(entry.getKey(), entry.getValue()[0]);
@@ -63,6 +65,7 @@ public class BaseBulkUploadController extends BaseController {
         byteArray = IOUtils.toByteArray(is);
       }
     } else if (null != formUrlEncodeddata) {
+      ProjectLogger.log("Data sent as form encoded data", LoggerEnum.INFO.name());
       // read data as string from request
       for (Entry<String, String[]> entry : formUrlEncodeddata.entrySet()) {
         map.put(entry.getKey(), entry.getValue()[0]);
@@ -72,6 +75,7 @@ public class BaseBulkUploadController extends BaseController {
               ((String) map.get(JsonKey.DATA)).getBytes(StandardCharsets.UTF_8));
       byteArray = IOUtils.toByteArray(is);
     } else if (null != requestData) {
+      ProjectLogger.log("Data sent as request", LoggerEnum.INFO.name());
       reqObj =
           (org.sunbird.common.request.Request)
               mapper.RequestMapper.mapRequest(
@@ -83,6 +87,7 @@ public class BaseBulkUploadController extends BaseController {
       reqObj.getRequest().remove(JsonKey.DATA);
       map.putAll(reqObj.getRequest());
     } else {
+      ProjectLogger.log("No recognized data", LoggerEnum.INFO.name());
       throw new ProjectCommonException(
           ResponseCode.invalidData.getErrorCode(),
           ResponseCode.invalidData.getErrorMessage(),

--- a/service/app/util/RequestInterceptor.java
+++ b/service/app/util/RequestInterceptor.java
@@ -133,6 +133,7 @@ public class RequestInterceptor {
         }
       }
     } catch (Exception e) {
+      ProjectLogger.log(e.getMessage() + e.getStackTrace());
       ProjectLogger.log("Likely a possibility? " + request.uri(), LoggerEnum.INFO.name());
     }
     return requestedForUserID;

--- a/service/app/util/RequestInterceptor.java
+++ b/service/app/util/RequestInterceptor.java
@@ -133,7 +133,7 @@ public class RequestInterceptor {
         }
       }
     } catch (Exception e) {
-      ProjectLogger.log("Likely a possibility? {}", request.uri(), LoggerEnum.INFO.name());
+      ProjectLogger.log("Likely a possibility? " + request.uri(), LoggerEnum.INFO.name());
     }
     return requestedForUserID;
   }


### PR DESCRIPTION
1. We have some observations that there are decrypt errors getting logged frequently. This could be happening on expected lines or not, due to legacy. This logging of value to be decrypted can help find this out - this will be reverted based on our experiment results.
2. In token verification, some null pointer exception is thrown. Adding a trace and softly ignoring this, as we could afford to for managed for tokens.
