### PR TITLE
SB-20253 Fix migrate user and SSo user read api to work with usr_external_identity migration

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
@@ -1343,8 +1343,7 @@ public class OrganisationManagementActor extends BaseActor {
     } else if (StringUtils.isNotBlank((String) data.get(JsonKey.USER_EXTERNAL_ID))
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_PROVIDER))
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_ID_TYPE))) {
-
-      /* Depreciated: No more externalId is stored as an encrypted format
+      // not used any more as externalids are not store in encrypted format now
       requestDbMap.put(JsonKey.PROVIDER, data.get(JsonKey.USER_PROVIDER));
       requestDbMap.put(JsonKey.ID_TYPE, data.get(JsonKey.USER_ID_TYPE));
       requestDbMap.put(
@@ -1353,7 +1352,7 @@ public class OrganisationManagementActor extends BaseActor {
       result =
           cassandraOperation.getRecordsByProperties(
               JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, requestDbMap);
-       */
+
       fromExtId = true;
     } else {
       usrDbInfo = Util.dbInfoMap.get(JsonKey.USER_DB);

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
@@ -1343,6 +1343,8 @@ public class OrganisationManagementActor extends BaseActor {
     } else if (StringUtils.isNotBlank((String) data.get(JsonKey.USER_EXTERNAL_ID))
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_PROVIDER))
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_ID_TYPE))) {
+
+      /* Depreciated: No more externalId is stored as an encrypted format
       requestDbMap.put(JsonKey.PROVIDER, data.get(JsonKey.USER_PROVIDER));
       requestDbMap.put(JsonKey.ID_TYPE, data.get(JsonKey.USER_ID_TYPE));
       requestDbMap.put(
@@ -1351,7 +1353,7 @@ public class OrganisationManagementActor extends BaseActor {
       result =
           cassandraOperation.getRecordsByProperties(
               JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, requestDbMap);
-      fromExtId = true;
+      fromExtId = true;*/
     } else {
       usrDbInfo = Util.dbInfoMap.get(JsonKey.USER_DB);
       requestDbMap.put(JsonKey.PROVIDER, data.get(JsonKey.PROVIDER));

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
@@ -1353,7 +1353,8 @@ public class OrganisationManagementActor extends BaseActor {
       result =
           cassandraOperation.getRecordsByProperties(
               JsonKey.SUNBIRD, JsonKey.USR_EXT_IDNT_TABLE, requestDbMap);
-      fromExtId = true;*/
+       */
+      fromExtId = true;
     } else {
       usrDbInfo = Util.dbInfoMap.get(JsonKey.USER_DB);
       requestDbMap.put(JsonKey.PROVIDER, data.get(JsonKey.PROVIDER));

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/OrganisationManagementActor.java
@@ -1344,6 +1344,8 @@ public class OrganisationManagementActor extends BaseActor {
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_PROVIDER))
         && StringUtils.isNotBlank((String) data.get(JsonKey.USER_ID_TYPE))) {
       // not used any more as externalids are not store in encrypted format now
+      ProjectLogger.log(
+          "This condition should not run, as external ids are not stored in encrypted format");
       requestDbMap.put(JsonKey.PROVIDER, data.get(JsonKey.USER_PROVIDER));
       requestDbMap.put(JsonKey.ID_TYPE, data.get(JsonKey.USER_ID_TYPE));
       requestDbMap.put(

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/TenantMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/TenantMigrationActor.java
@@ -176,6 +176,7 @@ public class TenantMigrationActor extends BaseActor {
     // Update user org details
     Response userOrgResponse =
         updateUserOrg(request, (List<Map<String, Object>>) userDetails.get(JsonKey.ORGANISATIONS));
+
     // Update user externalIds
     Response userExternalIdsResponse = updateUserExternalIds(request);
     // Collect all the error message
@@ -352,6 +353,8 @@ public class TenantMigrationActor extends BaseActor {
     userExtIdsReq.put(JsonKey.EXTERNAL_IDS, request.getRequest().get(JsonKey.EXTERNAL_IDS));
     try {
       ObjectMapper mapper = new ObjectMapper();
+      // Update channel to orgId  for provider field in usr_external_identiy table
+      UserUtil.updateExternalIdsProviderWithOrgId(userExtIdsReq);
       User user = mapper.convertValue(userExtIdsReq, User.class);
       UserUtil.validateExternalIds(user, JsonKey.CREATE);
       userExtIdsReq.put(JsonKey.EXTERNAL_IDS, user.getExternalIds());

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserManagementActor.java
@@ -248,8 +248,8 @@ public class UserManagementActor extends BaseActor {
     Map<String, Object> userMap = actorMessage.getRequest();
     userRequestValidator.validateUpdateUserRequest(actorMessage);
     validateUserOrganisations(actorMessage, isPrivate);
-    // update provider from channel to orgId
-    updateProviderWithOrgId(userMap);
+    // update externalIds provider from channel to orgId
+    UserUtil.updateExternalIdsProviderWithOrgId(userMap);
     Map<String, Object> userDbRecord = UserUtil.validateExternalIdsAndReturnActiveUser(userMap);
     String managedById = (String) userDbRecord.get(JsonKey.MANAGED_BY);
     if (!isPrivate) {
@@ -344,47 +344,6 @@ public class UserManagementActor extends BaseActor {
             (String) userMap.get(JsonKey.USER_ID), TelemetryEnvKey.USER, JsonKey.UPDATE, null);
     TelemetryUtil.telemetryProcessingCall(
         userMap, targetObject, correlatedObject, actorMessage.getContext());
-  }
-
-  private void updateProviderWithOrgId(Map<String, Object> userMap) {
-    if (MapUtils.isNotEmpty(userMap)) {
-      Set<String> providerSet = new HashSet<>();
-      if (StringUtils.isNotBlank((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER))) {
-        providerSet.add((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER));
-      }
-      List<Map<String, String>> extList =
-          (List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS);
-      if (CollectionUtils.isNotEmpty(extList)) {
-        for (Map<String, String> extId : extList) {
-          providerSet.add(extId.get(JsonKey.PROVIDER));
-        }
-      }
-
-      Map<String, String> orgProviderMap =
-          UserUtil.fetchOrgIdByProvider(new ArrayList<String>(providerSet));
-      if (StringUtils.isNotBlank((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER))) {
-        userMap.put(
-            JsonKey.EXTERNAL_ID_PROVIDER,
-            orgProviderMap.get((String) userMap.get(JsonKey.EXTERNAL_ID_PROVIDER)));
-      }
-      if (CollectionUtils.isNotEmpty(
-          (List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS))) {
-        for (Map<String, String> externalId :
-            (List<Map<String, String>>) userMap.get(JsonKey.EXTERNAL_IDS)) {
-
-          String orgId = orgProviderMap.get(externalId.get(JsonKey.PROVIDER));
-          if (StringUtils.isBlank(orgId)) {
-            ProjectCommonException.throwClientErrorException(
-                ResponseCode.invalidParameterValue,
-                MessageFormat.format(
-                    ResponseCode.invalidParameterValue.getErrorMessage(),
-                    JsonKey.PROVIDER,
-                    externalId.get(JsonKey.PROVIDER)));
-          }
-          externalId.put(JsonKey.PROVIDER, orgId);
-        }
-      }
-    }
   }
 
   private void updateLocationCodeToIds(List<Map<String, String>> externalIds) {
@@ -1009,6 +968,8 @@ public class UserManagementActor extends BaseActor {
     Map<String, Object> requestMap = null;
     UserUtil.setUserDefaultValue(userMap, callerId);
     ObjectMapper mapper = new ObjectMapper();
+    // Update external ids provider with OrgId
+    UserUtil.updateExternalIdsProviderWithOrgId(userMap);
     User user = mapper.convertValue(userMap, User.class);
     UserUtil.validateExternalIds(user, JsonKey.CREATE);
     userMap.put(JsonKey.EXTERNAL_IDS, user.getExternalIds());

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -264,6 +264,7 @@ public class UserProfileReadActor extends BaseActor {
               result.put(JsonKey.DECLARATIONS, declarations);
             }
             if (requestFields.contains(JsonKey.EXTERNAL_IDS)) {
+              ProjectLogger.log("Get external Ids explicitly from usr_external_identity for v3");
               List<Map<String, String>> resExternalIds =
                   userExternalIdentityService.getUserExternalIds(userId);
               decryptUserExternalIds(resExternalIds);
@@ -273,6 +274,8 @@ public class UserProfileReadActor extends BaseActor {
           }
         } else {
           // fetch user external identity
+          ProjectLogger.log(
+              "Get external Ids from both declarations and usr_external_identity for merge them");
           List<Map<String, String>> dbResExternalIds = fetchUserExternalIdentity(userId);
           result.put(JsonKey.EXTERNAL_IDS, dbResExternalIds);
         }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -267,7 +267,7 @@ public class UserProfileReadActor extends BaseActor {
               List<Map<String, String>> resExternalIds =
                   userExternalIdentityService.getUserExternalIds(userId);
               decryptUserExternalIds(resExternalIds);
-              updateExternalIdsWithProvider(resExternalIds);
+              UserUtil.updateExternalIdsWithProvider(resExternalIds);
               result.put(JsonKey.EXTERNAL_IDS, resExternalIds);
             }
           }
@@ -389,7 +389,7 @@ public class UserProfileReadActor extends BaseActor {
 
     decryptUserExternalIds(dbResExternalIds);
     // update orgId to provider in externalIds
-    updateExternalIdsWithProvider(dbResExternalIds);
+    UserUtil.updateExternalIdsWithProvider(dbResExternalIds);
     return dbResExternalIds;
   }
 
@@ -440,32 +440,6 @@ public class UserProfileReadActor extends BaseActor {
                 s.remove(JsonKey.CREATED_ON);
                 s.remove(JsonKey.USER_ID);
                 s.remove(JsonKey.SLUG);
-              });
-    }
-  }
-
-  /**
-   * Till 3.1.0 there will be only 1 provider will be active for a user in self declaration and user
-   * can migrate only to 1 state. TODO: Need fix .If a user can be migrated to multiple states in
-   * future
-   *
-   * @param dbResExternalIds
-   */
-  private void updateExternalIdsWithProvider(List<Map<String, String>> dbResExternalIds) {
-
-    if (CollectionUtils.isNotEmpty(dbResExternalIds)) {
-      String orgId = dbResExternalIds.get(0).get(JsonKey.PROVIDER);
-      String provider = UserUtil.fetchProviderByOrgId(orgId);
-      Set<String> providerSet = new HashSet<>();
-      dbResExternalIds
-          .stream()
-          .forEach(
-              s -> {
-                if (s.get(JsonKey.PROVIDER) != null
-                    && s.get(JsonKey.PROVIDER).equals(s.get(JsonKey.ID_TYPE))) {
-                  s.put(JsonKey.ID_TYPE, provider);
-                }
-                s.put(JsonKey.PROVIDER, provider);
               });
     }
   }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserProfileReadActor.java
@@ -216,9 +216,6 @@ public class UserProfileReadActor extends BaseActor {
         (String) actorMessage.getContext().getOrDefault(JsonKey.REQUESTED_BY, "");
     String managedForId = (String) actorMessage.getContext().getOrDefault(JsonKey.MANAGED_FOR, "");
     String managedBy = (String) result.get(JsonKey.MANAGED_BY);
-    managedBy = userId;
-    requestedById = managedBy;
-    managedForId = userId;
     ProjectLogger.log(
         "requested By and requested user id == "
             + requestedById

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/UserExternalIdentityService.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/UserExternalIdentityService.java
@@ -11,5 +11,7 @@ public interface UserExternalIdentityService {
 
   List<Map<String, String>> getUserExternalIds(String userId);
 
-  String getUser(String extId, String provider, String idType);
+  String getUserV1(String extId, String provider, String idType);
+
+  String getUserV2(String extId, String orgId, String idType);
 }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
@@ -1,13 +1,12 @@
 package org.sunbird.user.service.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.apache.commons.collections.CollectionUtils;
 import org.sunbird.user.dao.UserExternalIdentityDao;
 import org.sunbird.user.dao.impl.UserExternalIdentityDaoImpl;
 import org.sunbird.user.service.UserExternalIdentityService;
 import org.sunbird.user.util.UserExternalIdentityAdapter;
+import org.sunbird.user.util.UserUtil;
 
 public class UserExternalIdentityServiceImpl implements UserExternalIdentityService {
   private static UserExternalIdentityDao userExternalIdentityDao =
@@ -39,7 +38,14 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
   }
 
   @Override
-  public String getUser(String extId, String provider, String idType) {
-    return userExternalIdentityDao.getUserIdByExternalId(extId, provider, idType);
+  public String getUserV1(String extId, String provider, String idType) {
+    Map<String, String> providerOrgMap = UserUtil.fetchOrgIdByProvider(Arrays.asList(provider));
+    return userExternalIdentityDao.getUserIdByExternalId(
+        extId, providerOrgMap.get(provider), idType);
+  }
+
+  @Override
+  public String getUserV2(String extId, String orgId, String idType) {
+    return userExternalIdentityDao.getUserIdByExternalId(extId, orgId, idType);
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
@@ -37,6 +37,14 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
     return userExternalIdentityDao.getUserExternalIds(userId);
   }
 
+  /**
+   * Fetch userid using channel info from usr_external_identity table
+   *
+   * @param extId
+   * @param provider
+   * @param idType
+   * @return
+   */
   @Override
   public String getUserV1(String extId, String provider, String idType) {
     Map<String, String> providerOrgMap = UserUtil.fetchOrgIdByProvider(Arrays.asList(provider));
@@ -44,6 +52,14 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
         extId, providerOrgMap.get(provider), idType);
   }
 
+  /**
+   * Fetch userid using orgId info to support usr_external_identity table
+   *
+   * @param extId
+   * @param orgId
+   * @param idType
+   * @return
+   */
   @Override
   public String getUserV2(String extId, String orgId, String idType) {
     return userExternalIdentityDao.getUserIdByExternalId(extId, orgId, idType);

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -1048,11 +1048,13 @@ public class UserUtil {
             esUtil.search(searchDTO, ProjectUtil.EsType.organisation.getTypeName());
         Map<String, Object> esResOrg =
             (Map<String, Object>) ElasticSearchHelper.getResponseFromFuture(esOrgResF);
-        List<Map<String, Object>> orgList =
-            (List<Map<String, Object>>) esResOrg.get(JsonKey.CONTENT);
-        if (CollectionUtils.isNotEmpty(orgList)) {
-          for (Map<String, Object> org : orgList) {
-            providerOrgMap.put((String) org.get(JsonKey.CHANNEL), (String) org.get(JsonKey.ID));
+        if (MapUtils.isNotEmpty(esResOrg)) {
+          List<Map<String, Object>> orgList =
+              (List<Map<String, Object>>) esResOrg.get(JsonKey.CONTENT);
+          if (CollectionUtils.isNotEmpty(orgList)) {
+            for (Map<String, Object> org : orgList) {
+              providerOrgMap.put((String) org.get(JsonKey.CHANNEL), (String) org.get(JsonKey.ID));
+            }
           }
         }
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -386,6 +386,30 @@ public class UserUtil {
         });
   }
 
+  /**
+   * Till 3.1.0 there will be only 1 provider will be active for a user in self declaration and user
+   * can migrate only to 1 state. Note: Need fix .If a user can be migrated to multiple states in
+   * future
+   *
+   * @param dbResExternalIds
+   */
+  public static void updateExternalIdsWithProvider(List<Map<String, String>> dbResExternalIds) {
+    if (CollectionUtils.isNotEmpty(dbResExternalIds)) {
+      String orgId = dbResExternalIds.get(0).get(JsonKey.PROVIDER);
+      String provider = fetchProviderByOrgId(orgId);
+      dbResExternalIds
+          .stream()
+          .forEach(
+              s -> {
+                if (s.get(JsonKey.PROVIDER) != null
+                    && s.get(JsonKey.PROVIDER).equals(s.get(JsonKey.ID_TYPE))) {
+                  s.put(JsonKey.ID_TYPE, provider);
+                }
+                s.put(JsonKey.PROVIDER, provider);
+              });
+    }
+  }
+
   public static List<Map<String, String>> convertExternalIdsValueToLowerCase(
       List<Map<String, String>> externalIds) {
     ConvertValuesToLowerCase mapper =

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
@@ -100,7 +100,7 @@ public class SupportMultipleExternalIdsTest {
   }
 
   @Test
-  public void testCheckExternalIdUniquenessSuccessForCreate() {
+  public void testSuccessForCreate() {
 
     try {
       Util.checkExternalIdUniqueness(user, JsonKey.CREATE);

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/SupportMultipleExternalIdsTest.java
@@ -100,7 +100,7 @@ public class SupportMultipleExternalIdsTest {
   }
 
   @Test
-  public void testSuccessForCreate() {
+  public void testCheckExternalIdUniquenessSuccessForCreate() {
 
     try {
       Util.checkExternalIdUniqueness(user, JsonKey.CREATE);

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -1,0 +1,84 @@
+package org.sunbird.user.service;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.sunbird.cassandra.CassandraOperation;
+import org.sunbird.cassandraimpl.CassandraOperationImpl;
+import org.sunbird.common.models.response.Response;
+import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.helper.ServiceFactory;
+import org.sunbird.user.service.impl.UserExternalIdentityServiceImpl;
+import org.sunbird.user.util.UserUtil;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+  UserUtil.class,
+  ServiceFactory.class,
+  CassandraOperationImpl.class,
+})
+@PowerMockIgnore("javax.management.*")
+public class UserExternalIdentityServiceTest {
+
+  private static CassandraOperation cassandraOperationImpl;
+
+  @Before
+  public void beforeEachTest() {
+    PowerMockito.mockStatic(ServiceFactory.class);
+    cassandraOperationImpl = mock(CassandraOperation.class);
+    when(ServiceFactory.getInstance()).thenReturn(cassandraOperationImpl);
+  }
+
+  @Test
+  public void getUserV1Test() {
+    Map<String, Object> propertyMap = new HashMap<>();
+    Response response = new Response();
+    List<Map<String, Object>> resp = new ArrayList<>();
+    Map<String, Object> userList = new HashMap<>();
+    userList.put(JsonKey.USER_ID, "1234");
+    resp.add(userList);
+    response.put(JsonKey.RESPONSE, resp);
+    when(cassandraOperationImpl.getRecordsByProperties(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
+        .thenReturn(response);
+    Map<String, String> orgProviderMap = new HashMap<>();
+    orgProviderMap.put("channel1004", "01234567687");
+    PowerMockito.mockStatic(UserUtil.class);
+    when(UserUtil.fetchOrgIdByProvider(Mockito.anyList())).thenReturn(orgProviderMap);
+    UserExternalIdentityService userExternalIdentityService = new UserExternalIdentityServiceImpl();
+
+    String userId = userExternalIdentityService.getUserV1("1234", "channel1004", "channel1004");
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void getUserV2Test() {
+    Map<String, Object> propertyMap = new HashMap<>();
+    Response response = new Response();
+    List<Map<String, Object>> resp = new ArrayList<>();
+    Map<String, Object> userList = new HashMap<>();
+    userList.put(JsonKey.USER_ID, "1234");
+    resp.add(userList);
+    response.put(JsonKey.RESPONSE, resp);
+    when(cassandraOperationImpl.getRecordsByProperties(
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
+        .thenReturn(response);
+    UserExternalIdentityService userExternalIdentityService = new UserExternalIdentityServiceImpl();
+
+    String userId = userExternalIdentityService.getUserV2("1234", "channel1004", "channel1004");
+    Assert.assertTrue(true);
+  }
+}

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -335,5 +335,45 @@ public class UserUtilTest {
     List<Map<String, String>> externalIdList = new ArrayList<>();
     externalIdList.add(externalIds);
     UserUtil.updateExternalIdsWithProvider(externalIdList);
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testupdateExternalIdsProviderWithOrgId() {
+    beforeEachTest();
+    List<String> providers = new ArrayList<>();
+    providers.add("channel004");
+
+    Map<String, Object> orgMap = new HashMap<>();
+    List<Map<String, Object>> orgList = new ArrayList<>();
+
+    orgMap.put("id", "1234");
+    orgMap.put("channel", "channel004");
+    orgList.add(orgMap);
+    Map<String, Object> contentMap = new HashMap<>();
+    contentMap.put(JsonKey.CONTENT, orgList);
+
+    Promise<Map<String, Object>> promise = Futures.promise();
+    promise.success(contentMap);
+    Future<Map<String, Object>> test = promise.future();
+    SearchDTO searchDTO = new SearchDTO();
+    when(Util.createSearchDto(Mockito.anyMap())).thenReturn(searchDTO);
+    when(esService.search(searchDTO, ProjectUtil.EsType.organisation.getTypeName()))
+        .thenReturn(promise.future());
+    Map<String, String> externalIds = new HashMap<>();
+    externalIds.put(JsonKey.PROVIDER, "channel1004");
+    externalIds.put(JsonKey.USER_ID, "w131-2323-323-232-3232");
+    List<Map<String, String>> externalIdList = new ArrayList<>();
+    externalIdList.add(externalIds);
+    Map<String, Object> userMap = new HashMap<>();
+    userMap.put(JsonKey.EXTERNAL_IDS, externalIdList);
+    try {
+      UserUtil.updateExternalIdsProviderWithOrgId(userMap);
+    } catch (Exception ex) {
+      Assert.assertTrue(true);
+      Assert.assertEquals(
+          "Invalid value provider for parameter channel1004. Please provide a valid value.",
+          ex.getMessage());
+    }
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -306,4 +306,34 @@ public class UserUtilTest {
     List<Map<String, Object>> res = UserUtil.getActiveUserOrgDetails("123-456-789");
     Assert.assertNotNull(res);
   }
+
+  @Test
+  public void testupdateExternalIdsWithProvider() {
+    beforeEachTest();
+    List<String> providers = new ArrayList<>();
+    providers.add("channel004");
+
+    Map<String, Object> orgMap = new HashMap<>();
+    List<Map<String, Object>> orgList = new ArrayList<>();
+
+    orgMap.put("id", "1234");
+    orgMap.put("channel", "channel004");
+    orgList.add(orgMap);
+    Map<String, Object> contentMap = new HashMap<>();
+    contentMap.put(JsonKey.CONTENT, orgList);
+
+    Promise<Map<String, Object>> promise = Futures.promise();
+    promise.success(contentMap);
+    Future<Map<String, Object>> test = promise.future();
+    SearchDTO searchDTO = new SearchDTO();
+    when(Util.createSearchDto(Mockito.anyMap())).thenReturn(searchDTO);
+    when(esService.search(searchDTO, ProjectUtil.EsType.organisation.getTypeName()))
+        .thenReturn(promise.future());
+    Map<String, String> externalIds = new HashMap<>();
+    externalIds.put(JsonKey.PROVIDER, "1234");
+    externalIds.put(JsonKey.USER_ID, "w131-2323-323-232-3232");
+    List<Map<String, String>> externalIdList = new ArrayList<>();
+    externalIdList.add(externalIds);
+    UserUtil.updateExternalIdsWithProvider(externalIdList);
+  }
 }


### PR DESCRIPTION
Update:
 Fix to read SSO user to work with usr_external_identity table with orgId
 Migrate user to update orgId in the usr_external_identity table.
 Refactor code to reuse the components