### PR TITLE
SH-999 Remove org id column and use channel as main identifier

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
@@ -411,9 +411,6 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
             case "diksha sub-org id":
               mappedColumns.add("subOrgId");
               break;
-            case "org id":
-              mappedColumns.add(JsonKey.ORG_ID);
-              break;
             case "persona":
               mappedColumns.add(column);
               break;
@@ -547,9 +544,6 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
     }
     if (columnAttribute.equalsIgnoreCase(JsonKey.ERROR_TYPE)) {
       migrationUser.setErrorType((String) value);
-    }
-    if (columnAttribute.equalsIgnoreCase(JsonKey.ORG_ID)) {
-      migrationUser.setOrgId((String) value);
     }
   }
 

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
@@ -141,7 +141,7 @@ public class UserBulkMigrationRequestValidator {
     } else if (!Stream.of(SelfDeclaredErrorTypeEnum.values())
         .map(Enum::name)
         .collect(Collectors.toList())
-        .contains(errorType)) {
+        .contains(errorType.replace("-", "_"))) {
       errorDetails.setHeader("Error Type");
       errorDetails.setErrorEnum(ErrorEnum.invalid);
       addErrorToList(errorDetails);

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
@@ -120,13 +120,29 @@ public class UserBulkMigrationRequestValidator {
   }
 
   private void validateSelfDeclaredUser(SelfDeclaredUser migrationUser, int index) {
-    checkUserExternalId(migrationUser.getUserExternalId(), index);
+    checkUserDeclaredExternalId(migrationUser.getUserExternalId(), index);
     checkSelfDeclaredInputStatus(migrationUser.getInputStatus(), index);
     if ((migrationUser.getInputStatus().equals(JsonKey.SELF_DECLARED_ERROR))) {
       checkSelfDeclaredErrorTypeIfPresent(migrationUser.getErrorType(), index);
     }
     checkValue(migrationUser.getUserId(), index, JsonKey.DIKSHA_UUID);
     checkValue(migrationUser.getChannel(), index, JsonKey.CHANNEL);
+    checkValue(migrationUser.getPersona(), index, JsonKey.PERSONA);
+  }
+
+  private void checkUserDeclaredExternalId(String userExternalId, int index) {
+    CsvRowErrorDetails errorDetails = new CsvRowErrorDetails();
+    errorDetails.setRowId(index);
+    errorDetails.setHeader(JsonKey.STATE_PROVIDED_EXT_ID);
+    if (StringUtils.isBlank(userExternalId)) {
+      errorDetails.setErrorEnum(ErrorEnum.missing);
+    }
+    if (!userExternalIdsSet.add(userExternalId)) {
+      errorDetails.setErrorEnum(ErrorEnum.duplicate);
+    }
+    if (errorDetails.getErrorEnum() != null) {
+      addErrorToList(errorDetails);
+    }
   }
 
   private void checkSelfDeclaredErrorTypeIfPresent(String errorType, int index) {

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
@@ -120,6 +120,7 @@ public class UserBulkMigrationRequestValidator {
   }
 
   private void validateSelfDeclaredUser(SelfDeclaredUser migrationUser, int index) {
+    checkUserDeclaredExternalId(migrationUser.getUserExternalId(), index);
     checkSelfDeclaredInputStatus(migrationUser.getInputStatus(), index);
     if ((migrationUser.getInputStatus().equals(JsonKey.SELF_DECLARED_ERROR))) {
       checkSelfDeclaredErrorTypeIfPresent(migrationUser.getErrorType(), index);
@@ -127,7 +128,21 @@ public class UserBulkMigrationRequestValidator {
     checkValue(migrationUser.getUserId(), index, JsonKey.DIKSHA_UUID);
     checkValue(migrationUser.getChannel(), index, JsonKey.CHANNEL);
     checkValue(migrationUser.getPersona(), index, JsonKey.PERSONA);
-    checkValue(migrationUser.getUserExternalId(), index, JsonKey.STATE_PROVIDED_EXT_ID);
+  }
+
+  private void checkUserDeclaredExternalId(String userExternalId, int index) {
+    CsvRowErrorDetails errorDetails = new CsvRowErrorDetails();
+    errorDetails.setRowId(index);
+    errorDetails.setHeader(JsonKey.STATE_PROVIDED_EXT_ID);
+    if (StringUtils.isBlank(userExternalId)) {
+      errorDetails.setErrorEnum(ErrorEnum.missing);
+    }
+    if (!userExternalIdsSet.add(userExternalId)) {
+      errorDetails.setErrorEnum(ErrorEnum.duplicate);
+    }
+    if (errorDetails.getErrorEnum() != null) {
+      addErrorToList(errorDetails);
+    }
   }
 
   private void checkSelfDeclaredErrorTypeIfPresent(String errorType, int index) {

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/validator/user/UserBulkMigrationRequestValidator.java
@@ -120,7 +120,6 @@ public class UserBulkMigrationRequestValidator {
   }
 
   private void validateSelfDeclaredUser(SelfDeclaredUser migrationUser, int index) {
-    checkUserDeclaredExternalId(migrationUser.getUserExternalId(), index);
     checkSelfDeclaredInputStatus(migrationUser.getInputStatus(), index);
     if ((migrationUser.getInputStatus().equals(JsonKey.SELF_DECLARED_ERROR))) {
       checkSelfDeclaredErrorTypeIfPresent(migrationUser.getErrorType(), index);
@@ -128,21 +127,7 @@ public class UserBulkMigrationRequestValidator {
     checkValue(migrationUser.getUserId(), index, JsonKey.DIKSHA_UUID);
     checkValue(migrationUser.getChannel(), index, JsonKey.CHANNEL);
     checkValue(migrationUser.getPersona(), index, JsonKey.PERSONA);
-  }
-
-  private void checkUserDeclaredExternalId(String userExternalId, int index) {
-    CsvRowErrorDetails errorDetails = new CsvRowErrorDetails();
-    errorDetails.setRowId(index);
-    errorDetails.setHeader(JsonKey.STATE_PROVIDED_EXT_ID);
-    if (StringUtils.isBlank(userExternalId)) {
-      errorDetails.setErrorEnum(ErrorEnum.missing);
-    }
-    if (!userExternalIdsSet.add(userExternalId)) {
-      errorDetails.setErrorEnum(ErrorEnum.duplicate);
-    }
-    if (errorDetails.getErrorEnum() != null) {
-      addErrorToList(errorDetails);
-    }
+    checkValue(migrationUser.getUserExternalId(), index, JsonKey.STATE_PROVIDED_EXT_ID);
   }
 
   private void checkSelfDeclaredErrorTypeIfPresent(String errorType, int index) {

--- a/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/validator/user/UserBulkMigrationRequestValidatorTest.java
+++ b/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/validator/user/UserBulkMigrationRequestValidatorTest.java
@@ -308,7 +308,7 @@ public class UserBulkMigrationRequestValidatorTest {
           .validateDeclaredUsers();
     } catch (Exception e) {
       Assert.assertEquals(
-          "[ In Row 1:the Column status:is invalid, In Row 1:the Column Diksha UUID:is missing ]",
+          "[ In Row 1:the Column status:is invalid, In Row 1:the Column Diksha UUID:is missing, In Row 1:the Column persona:is missing ]",
           e.getMessage());
     }
   }
@@ -324,6 +324,7 @@ public class UserBulkMigrationRequestValidatorTest {
     declaredUser.setUserExternalId("user ext id");
     declaredUser.setInputStatus("INVALIDATED");
     declaredUser.setUserId("user ext id");
+    declaredUser.setPersona("teacher");
     declaredUserList.add(declaredUser);
     try {
       new ShadowUserUpload.ShadowUserUploadBuilder()
@@ -347,6 +348,7 @@ public class UserBulkMigrationRequestValidatorTest {
     declaredUser.setUserId("user ext id");
     declaredUser.setErrorType("INVALIDATED");
     declaredUser.setUserExternalId("user ext id");
+    declaredUser.setPersona("teacher");
     declaredUserList.add(declaredUser);
     try {
       new ShadowUserUpload.ShadowUserUploadBuilder()

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -1067,13 +1067,14 @@ public final class JsonKey {
   public static final String SELF_DECLARED_OPTIONAL_FIELDS = "self_declared_optional_fields";
   public static final String SELF_DECLARED_USER_OBJECT = "SELF_DECLARED_USER";
   public static final String DIKSHA_UUID = "Diksha UUID";
+  public static final String STATE_PROVIDED_EXT_ID = "State provided ext. ID";
   public static final String USER_INFO = "userInfo";
   public static final String USR_DECLARATION_TABLE = "user_declarations";
   public static final String ERROR_TYPE = "errorType";
   public static final String DECLARATIONS = "declarations";
   public static final String PERSONA = "persona";
-  //This denotes the persona of the user in self declaration and
-  //is different from role or user type = TEACHER
+  // This denotes the persona of the user in self declaration and
+  // is different from role or user type = TEACHER
   public static final String TEACHER_PERSONA = "teacher";
   public static final String TENANT_PREFERENCE_V2 = "tenantPreferenceV2";
 

--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -203,6 +203,6 @@ limit_managed_user_creation=true
 managed_user_limit=30
 adminutil_base_url = http://adminutil:4000/
 adminutil_sign_endpoint = v1/sign/payload
-self_declared_mandatory_fields = Diksha UUID,Status,State provided ext. ID,Channel,Org ID,Persona
+self_declared_mandatory_fields = Diksha UUID,Status,State provided ext. ID,Channel,Persona
 self_declared_optional_fields = School Name,School UDISE ID,Email ID,Diksha Sub-Org ID,Error Type
 enable_captcha=true


### PR DESCRIPTION
Removed orgid column and its related mandatory validation from self-user bulkupload csv.
Removed validation that is checking for duplicate user external id(State provided ext. ID).