### PR TITLE
SB-17965: changed keycloak-admin-client version  to 3.2.0.Final

### DIFF
--- a/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/pom.xml
+++ b/actors/sunbird-lms-mw/actors/sunbird-utils/sunbird-platform-core/common-util/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-admin-client</artifactId>
-			<version>6.0.1</version>
+			<version>3.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
user is unable to block the account through block API: changed keycloak-admin-client version from 6.2.0 to 3.2.0.Final