### PR TITLE
SC-2021: Redirect the call to user_lookup table - getUserIdByExternalId() in UserExternalIdentityDaoImpl

### DIFF
--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/UserExternalIdentityDao.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/UserExternalIdentityDao.java
@@ -6,8 +6,7 @@ import org.sunbird.common.request.RequestContext;
 
 public interface UserExternalIdentityDao {
 
-  public String getUserIdByExternalId(
-      String extId, String provider, String idType, RequestContext context);
+  public String getUserIdByExternalId(String extId, String provider, RequestContext context);
 
   public List<Map<String, String>> getUserExternalIds(String userId, RequestContext context);
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
@@ -9,38 +9,43 @@ import org.sunbird.cassandra.CassandraOperation;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.models.response.Response;
 import org.sunbird.common.models.util.JsonKey;
+import org.sunbird.common.models.util.LoggerUtil;
 import org.sunbird.common.models.util.datasecurity.EncryptionService;
 import org.sunbird.common.request.RequestContext;
 import org.sunbird.common.responsecode.ResponseCode;
 import org.sunbird.helper.ServiceFactory;
-import org.sunbird.learner.util.Util;
 import org.sunbird.user.dao.UserExternalIdentityDao;
+import org.sunbird.user.util.UserLookUp;
 
 public class UserExternalIdentityDaoImpl implements UserExternalIdentityDao {
 
+  private static LoggerUtil logger = new LoggerUtil(UserExternalIdentityDaoImpl.class);
   private CassandraOperation cassandraOperation = ServiceFactory.getInstance();
   private EncryptionService encryptionService =
       org.sunbird.common.models.util.datasecurity.impl.ServiceFactory.getEncryptionServiceInstance(
           null);
 
   @Override
-  public String getUserIdByExternalId(
-      String extId, String provider, String idType, RequestContext context) {
-    Util.DbInfo usrDbInfo = Util.dbInfoMap.get(JsonKey.USER_DB);
-    Map<String, Object> externalIdReq = new HashMap<>();
-    externalIdReq.put(JsonKey.PROVIDER, provider.toLowerCase());
-    externalIdReq.put(JsonKey.ID_TYPE, idType.toLowerCase());
-    externalIdReq.put(JsonKey.EXTERNAL_ID, extId.toLowerCase());
-    Response response =
-        cassandraOperation.getRecordsByProperties(
-            usrDbInfo.getKeySpace(), JsonKey.USR_EXT_IDNT_TABLE, externalIdReq, context);
-
+  public String getUserIdByExternalId(String extId, String provider, RequestContext context) {
+    UserLookUp userLookUp = new UserLookUp();
     List<Map<String, Object>> userRecordList =
-        (List<Map<String, Object>>) response.get(JsonKey.RESPONSE);
+        userLookUp.getRecordByType(
+            JsonKey.USER_LOOKUP_FILED_EXTERNAL_ID,
+            extId.toLowerCase() + "@" + provider.toLowerCase(),
+            false,
+            context);
     if (CollectionUtils.isNotEmpty(userRecordList)) {
+      logger.info(
+          context,
+          "getUserIdByExternalId: got userId from user_lookup for extId "
+              + extId
+              + " "
+              + (String) userRecordList.get(0).get(JsonKey.USER_ID));
       return (String) userRecordList.get(0).get(JsonKey.USER_ID);
     }
-
+    logger.info(
+        context,
+        "getUserIdByExternalId: got userId from user_lookup for extId " + extId + " is null");
     return null;
   }
 

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/dao/impl/UserExternalIdentityDaoImpl.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sunbird.cassandra.CassandraOperation;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.models.response.Response;
@@ -27,21 +28,20 @@ public class UserExternalIdentityDaoImpl implements UserExternalIdentityDao {
 
   @Override
   public String getUserIdByExternalId(String extId, String provider, RequestContext context) {
-    UserLookUp userLookUp = new UserLookUp();
-    List<Map<String, Object>> userRecordList =
-        userLookUp.getRecordByType(
-            JsonKey.USER_LOOKUP_FILED_EXTERNAL_ID,
-            extId.toLowerCase() + "@" + provider.toLowerCase(),
-            false,
-            context);
-    if (CollectionUtils.isNotEmpty(userRecordList)) {
-      logger.info(
-          context,
-          "getUserIdByExternalId: got userId from user_lookup for extId "
-              + extId
-              + " "
-              + (String) userRecordList.get(0).get(JsonKey.USER_ID));
-      return (String) userRecordList.get(0).get(JsonKey.USER_ID);
+    if (StringUtils.isNotEmpty((provider))) {
+      UserLookUp userLookUp = new UserLookUp();
+      List<Map<String, Object>> userRecordList =
+          userLookUp.getRecordByType(
+              JsonKey.USER_LOOKUP_FILED_EXTERNAL_ID, extId + "@" + provider, false, context);
+      if (CollectionUtils.isNotEmpty(userRecordList)) {
+        logger.info(
+            context,
+            "getUserIdByExternalId: got userId from user_lookup for extId "
+                + extId
+                + " "
+                + (String) userRecordList.get(0).get(JsonKey.USER_ID));
+        return (String) userRecordList.get(0).get(JsonKey.USER_ID);
+      }
     }
     logger.info(
         context,

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
@@ -51,8 +51,8 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
   public String getUserV1(String extId, String provider, String idType, RequestContext context) {
     Map<String, String> providerOrgMap =
         UserUtil.fetchOrgIdByProvider(Arrays.asList(provider), context);
-    return userExternalIdentityDao.getUserIdByExternalId(
-        extId, providerOrgMap.get(provider), context);
+    String orgId = UserUtil.getCaseInsensitiveOrgFromProvider(provider, providerOrgMap);
+    return userExternalIdentityDao.getUserIdByExternalId(extId, orgId, context);
   }
 
   /**

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/service/impl/UserExternalIdentityServiceImpl.java
@@ -52,10 +52,7 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
     Map<String, String> providerOrgMap =
         UserUtil.fetchOrgIdByProvider(Arrays.asList(provider), context);
     return userExternalIdentityDao.getUserIdByExternalId(
-        extId,
-        providerOrgMap.get(provider),
-        provider.equals(idType) ? providerOrgMap.get(idType) : idType,
-        context);
+        extId, providerOrgMap.get(provider), context);
   }
 
   /**
@@ -69,6 +66,6 @@ public class UserExternalIdentityServiceImpl implements UserExternalIdentityServ
    */
   @Override
   public String getUserV2(String extId, String orgId, String idType, RequestContext context) {
-    return userExternalIdentityDao.getUserIdByExternalId(extId, orgId, idType, context);
+    return userExternalIdentityDao.getUserIdByExternalId(extId, orgId, context);
   }
 }

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -51,7 +51,7 @@ public class UserExternalIdentityServiceTest {
     userList.put(JsonKey.USER_ID, "1234");
     resp.add(userList);
     response.put(JsonKey.RESPONSE, resp);
-    when(cassandraOperationImpl.getRecordsByProperties(
+    when(cassandraOperationImpl.getRecordsByCompositeKey(
             Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.any()))
         .thenReturn(response);
     Map<String, String> orgProviderMap = new HashMap<>();
@@ -75,7 +75,7 @@ public class UserExternalIdentityServiceTest {
     userList.put(JsonKey.USER_ID, "1234");
     resp.add(userList);
     response.put(JsonKey.RESPONSE, resp);
-    when(cassandraOperationImpl.getRecordsByProperties(
+    when(cassandraOperationImpl.getRecordsByCompositeKey(
             Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.any()))
         .thenReturn(response);
     UserExternalIdentityService userExternalIdentityService = new UserExternalIdentityServiceImpl();

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -68,7 +68,10 @@ public class UserExternalIdentityServiceTest {
 
   @Test
   public void getUserV2Test() {
-    Map<String, Object> propertyMap = new HashMap<>();
+    PowerMockito.mockStatic(ServiceFactory.class);
+    CassandraOperation cassandraOperationImpl;
+    cassandraOperationImpl = mock(CassandraOperation.class);
+    when(ServiceFactory.getInstance()).thenReturn(cassandraOperationImpl);
     Response response = new Response();
     List<Map<String, Object>> resp = new ArrayList<>();
     Map<String, Object> userList = new HashMap<>();

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -59,6 +59,8 @@ public class UserExternalIdentityServiceTest {
     PowerMockito.mockStatic(UserUtil.class);
     when(UserUtil.fetchOrgIdByProvider(Mockito.anyList(), Mockito.any()))
         .thenReturn(orgProviderMap);
+    when(UserUtil.getCaseInsensitiveOrgFromProvider(Mockito.anyString(), Mockito.anyMap()))
+        .thenReturn("01234567687");
     UserExternalIdentityService userExternalIdentityService = new UserExternalIdentityServiceImpl();
 
     String userId =
@@ -69,9 +71,6 @@ public class UserExternalIdentityServiceTest {
   @Test
   public void getUserV2Test() {
     PowerMockito.mockStatic(ServiceFactory.class);
-    CassandraOperation cassandraOperationImpl;
-    cassandraOperationImpl = mock(CassandraOperation.class);
-    when(ServiceFactory.getInstance()).thenReturn(cassandraOperationImpl);
     Response response = new Response();
     List<Map<String, Object>> resp = new ArrayList<>();
     Map<String, Object> userList = new HashMap<>();

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -70,7 +70,7 @@ public class UserExternalIdentityServiceTest {
 
   @Test
   public void getUserV2Test() {
-    PowerMockito.mockStatic(ServiceFactory.class);
+    Map<String, Object> propertyMap = new HashMap<>();
     Response response = new Response();
     List<Map<String, Object>> resp = new ArrayList<>();
     Map<String, Object> userList = new HashMap<>();

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/service/UserExternalIdentityServiceTest.java
@@ -103,7 +103,7 @@ public class UserExternalIdentityServiceTest {
     Map user = new HashMap();
     user.put(JsonKey.USER_ID, "1234");
     when(cassandraOperationImpl.getRecordById(
-            JsonKey.SUNBIRD, JsonKey.USR_DECLARATION_TABLE, user, null))
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.any()))
         .thenReturn(response);
     UserExternalIdentityService userExternalIdentityService = new UserExternalIdentityServiceImpl();
     List selfDeclareExternalId = userExternalIdentityService.getSelfDeclaredDetails("1234", null);


### PR DESCRIPTION
getUserIdByExternalId() was using  usr_external_identity table, to get userId, now it is redirected to user_lookup table

@sknirmalkar89  mentioned that getCaseInsensitiveOrgFromProvider() is not merged in release-3.3.0, getCaseInsensitiveOrgFromProvide() added back