### PR TITLE
SC-1954: Ensure public role always with a valid user

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkUploadBackgroundJobActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkUploadBackgroundJobActor.java
@@ -141,6 +141,9 @@ public class UserBulkUploadBackgroundJobActor extends BaseBulkUploadBackgroundJo
                   x -> {
                     roleList.add(x.trim());
                   });
+          if (!roleList.contains(ProjectUtil.UserRole.PUBLIC.getValue())) {
+            roleList.add(ProjectUtil.UserRole.PUBLIC.getValue());
+          }
           userMap.put(JsonKey.ROLES, roleList);
           RoleService.validateRoles((List<String>) userMap.get(JsonKey.ROLES));
         }


### PR DESCRIPTION
Had checked the APIs /v1/user/create,/v2/user/create, /v3/user/create, /v4/user/create,/v1/user/signup By default Public role is been added in all these cases. roles are added in both user and user-organization table. Even if roles are sent explicitly in the req it is not picked.

/v1/user/upload and /v1/user/upload, by default  public role, is not added  in both user and user-organization table and if roles are sent explicitly in the CSV it is picked(note: roles are mandatory in CSV file), If roles in the CSV  doesn't contain public role, added public role by default(this PR has the changes),
