### PR TITLE
SC-2026 Fix autodeploy script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,13 +32,10 @@ node('build-slave') {
             stage('Build') {
                 env.NODE_ENV = "build"
                 print "Environment will be : ${env.NODE_ENV}"
-                sh('git submodule update --init')
-                sh('git submodule update --init --recursive --remote')
                 sh 'git log -1'
-                sh 'cat service/conf/routes | grep v2'
                 sh 'mvn clean install -U -DskipTests=true '
-
             }
+
             stage('Unit Tests') {
                 sh "mvn clean install '-Dtest=!%regex[io.opensaber.registry.client.*]' -DfailIfNoTests=false"
             }

--- a/auto_build_deploy
+++ b/auto_build_deploy
@@ -27,16 +27,7 @@ node('build-slave') {
 
         //    stage Build
                 env.NODE_ENV = "build"
-                print "Environment will be : ${env.NODE_ENV}"
-                sh('git submodule update --init')
-                sh('git submodule update --init --recursive --remote')
-                sh 'git log -1'
-                sh 'cat service/conf/routes | grep v2'
-                sh 'mvn clean install -U -DskipTests=true '
-
-            
-        //    stage Unit Tests
-                sh "mvn test '-Dtest=!%regex[io.opensaber.registry.client.*]' -DfailIfNoTests=false"	
+                sh 'mvn clean install -U -DskipTests=false '
             
        //     stage Package
                 dir('service') {


### PR DESCRIPTION
Without auto-deploy, non-dev environments progression wont happen.
`mvn test` still fails and this is a stop gap arrangement until we find the right way to address this.