### PR TITLE
Sb 20852 Deleting email,phone and username from user_lookup in account merge scenario

### DIFF
--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserMergeActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserMergeActor.java
@@ -105,8 +105,7 @@ public class UserMergeActor extends UserBaseActor {
       UserDao userDao = UserDaoImpl.getInstance();
       Response mergeeResponse = userDao.updateUser(mergeeDBMap, userRequest.getRequestContext());
       List<String> userLookUpIdentifiers =
-          Stream.of(JsonKey.EMAIL, JsonKey.PHONE, JsonKey.USERNAME.toLowerCase())
-              .collect(Collectors.toList());
+          Stream.of(JsonKey.EMAIL, JsonKey.PHONE, JsonKey.USERNAME).collect(Collectors.toList());
       UserUtil.removeEntryFromUserLookUp(
           objectMapper.convertValue(mergee, Map.class), userLookUpIdentifiers, context);
       String mergeeResponseStr = (String) mergeeResponse.get(JsonKey.RESPONSE);

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserMergeActor.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/actors/UserMergeActor.java
@@ -105,7 +105,8 @@ public class UserMergeActor extends UserBaseActor {
       UserDao userDao = UserDaoImpl.getInstance();
       Response mergeeResponse = userDao.updateUser(mergeeDBMap, userRequest.getRequestContext());
       List<String> userLookUpIdentifiers =
-          Stream.of(JsonKey.EMAIL, JsonKey.PHONE, JsonKey.USERNAME).collect(Collectors.toList());
+          Stream.of(JsonKey.EMAIL, JsonKey.PHONE, JsonKey.USERNAME.toLowerCase())
+              .collect(Collectors.toList());
       UserUtil.removeEntryFromUserLookUp(
           objectMapper.convertValue(mergee, Map.class), userLookUpIdentifiers, context);
       String mergeeResponseStr = (String) mergeeResponse.get(JsonKey.RESPONSE);

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -927,8 +927,13 @@ public class UserUtil {
         && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.USERNAME))) {
       deleteLookUp = new HashMap<>();
       deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME);
-      deleteLookUp.put(
-          JsonKey.VALUE, transliterateUserName((String) userDbMap.get(JsonKey.USERNAME)));
+      String userName = transliterateUserName((String) userDbMap.get(JsonKey.USERNAME));
+      deleteLookUp.put(JsonKey.VALUE, userName);
+      logger.info(
+          context,
+          "UserUtil:removeEntryFromUserLookUp before transliterating username: "
+              + (String) userDbMap.get(JsonKey.USERNAME));
+      logger.info(context, "UserUtil:removeEntryFromUserLookUp username: " + userName);
       reqMap.add(deleteLookUp);
     }
     if (CollectionUtils.isNotEmpty(reqMap)) {

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -901,6 +901,40 @@ public class UserUtil {
 
     return userDeclareEntity;
   }
+
+  public static void removeEntryFromUserLookUp(
+      Map<String, Object> userDbMap, List<String> identifiers, RequestContext context) {
+    logger.info(
+        context,
+        "UserUtil:removeEntryFromUserLookUp remove following identifiers from lookUp table "
+            + identifiers);
+    List<Map<String, String>> reqMap = new ArrayList<>();
+    Map<String, String> deleteLookUp = new HashMap<>();
+    if (identifiers.contains(JsonKey.EMAIL)
+        && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.EMAIL))) {
+      deleteLookUp.put(JsonKey.TYPE, JsonKey.EMAIL);
+      deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.EMAIL));
+      reqMap.add(deleteLookUp);
+    }
+    if (identifiers.contains(JsonKey.PHONE)
+        && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.PHONE))) {
+      deleteLookUp = new HashMap<>();
+      deleteLookUp.put(JsonKey.TYPE, JsonKey.PHONE);
+      deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.PHONE));
+      reqMap.add(deleteLookUp);
+    }
+    if (identifiers.contains(JsonKey.USERNAME)
+        && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.USERNAME))) {
+      deleteLookUp = new HashMap<>();
+      deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME);
+      deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.USERNAME));
+      reqMap.add(deleteLookUp);
+    }
+    if (CollectionUtils.isNotEmpty(reqMap)) {
+      UserLookUp userLookUp = new UserLookUp();
+      userLookUp.deleteRecords(reqMap, context);
+    }
+  }
 }
 
 @FunctionalInterface

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -926,7 +926,7 @@ public class UserUtil {
     if (identifiers.contains(JsonKey.USERNAME)
         && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.USERNAME))) {
       deleteLookUp = new HashMap<>();
-      deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME);
+      deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME.toLowerCase());
       deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.USERNAME));
       logger.info(
           context,

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -927,7 +927,8 @@ public class UserUtil {
         && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.USERNAME))) {
       deleteLookUp = new HashMap<>();
       deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME);
-      deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.USERNAME));
+      deleteLookUp.put(
+          JsonKey.VALUE, transliterateUserName((String) userDbMap.get(JsonKey.USERNAME)));
       reqMap.add(deleteLookUp);
     }
     if (CollectionUtils.isNotEmpty(reqMap)) {

--- a/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
+++ b/actors/sunbird-lms-mw/actors/user/src/main/java/org/sunbird/user/util/UserUtil.java
@@ -927,13 +927,11 @@ public class UserUtil {
         && StringUtils.isNotBlank((String) userDbMap.get(JsonKey.USERNAME))) {
       deleteLookUp = new HashMap<>();
       deleteLookUp.put(JsonKey.TYPE, JsonKey.USERNAME);
-      String userName = transliterateUserName((String) userDbMap.get(JsonKey.USERNAME));
-      deleteLookUp.put(JsonKey.VALUE, userName);
+      deleteLookUp.put(JsonKey.VALUE, (String) userDbMap.get(JsonKey.USERNAME));
       logger.info(
           context,
           "UserUtil:removeEntryFromUserLookUp before transliterating username: "
               + (String) userDbMap.get(JsonKey.USERNAME));
-      logger.info(context, "UserUtil:removeEntryFromUserLookUp username: " + userName);
       reqMap.add(deleteLookUp);
     }
     if (CollectionUtils.isNotEmpty(reqMap)) {

--- a/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
+++ b/actors/sunbird-lms-mw/actors/user/src/test/java/org/sunbird/user/util/UserUtilTest.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +51,8 @@ import scala.concurrent.Promise;
   DefaultEncryptionServivceImpl.class,
   Util.class,
   EncryptionService.class,
-  org.sunbird.common.models.util.datasecurity.impl.ServiceFactory.class
+  org.sunbird.common.models.util.datasecurity.impl.ServiceFactory.class,
+  UserLookUp.class
 })
 @PowerMockIgnore({"javax.management.*"})
 public class UserUtilTest {
@@ -88,7 +91,10 @@ public class UserUtilTest {
     PowerMockito.mockStatic(EsClientFactory.class);
     esService = mock(ElasticSearchRestHighImpl.class);
     when(EsClientFactory.getInstance(Mockito.anyString())).thenReturn(esService);
-
+    PowerMockito.when(
+            cassandraOperationImpl.deleteRecord(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+        .thenReturn(response);
     PowerMockito.mockStatic(Util.class);
   }
 
@@ -433,6 +439,19 @@ public class UserUtilTest {
     requestMap.put(JsonKey.PHONE, "9999999999");
     requestMap.put(JsonKey.EMAIL, "sunbird@example.com");
     UserUtil.addMaskEmailAndMaskPhone(requestMap);
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testRemoveEntryFromUserLookUp() {
+    beforeEachTest();
+    Map<String, Object> mergeeMap = new HashMap<>();
+    mergeeMap.put(JsonKey.EMAIL, "someEmail");
+    mergeeMap.put(JsonKey.PHONE, "somePhone");
+    mergeeMap.put(JsonKey.USERNAME, "someUsername");
+    List<String> userLookUpIdentifiers =
+        Stream.of(JsonKey.EMAIL, JsonKey.PHONE, JsonKey.USERNAME).collect(Collectors.toList());
+    UserUtil.removeEntryFromUserLookUp(mergeeMap, userLookUpIdentifiers, new RequestContext());
     Assert.assertTrue(true);
   }
 }


### PR DESCRIPTION
During user-merge scenario, we are nullyfing username, phone and email of mergee details.
When any new account is creating with same mergee details again(say email, phone), application is saying email already exists.
So mergee details are removed from user_lookup table.