### PR TITLE
SH-999 comparing header size with each entry of csv

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/bulkupload/UserBulkMigrationActor.java
@@ -298,7 +298,7 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
     checkCsvHeader(csvHeaders, mandatoryHeaders, supportedHeaders);
     List<String> mappedCsvHeaders = mapSelfDeclaredCsvColumn(csvHeaders);
     List<SelfDeclaredUser> selfDeclaredUserList =
-        parseSelfDeclaredCsvRows(getCsvRowsAsList(csvData), mappedCsvHeaders);
+        parseSelfDeclaredCsvRows(getCsvRowsAsList(csvData), mappedCsvHeaders, csvHeaders.size());
     ShadowUserUpload migration =
         new ShadowUserUpload.ShadowUserUploadBuilder()
             .setHeaders(csvHeaders)
@@ -447,7 +447,7 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
   }
 
   private List<SelfDeclaredUser> parseSelfDeclaredCsvRows(
-      List<String[]> values, List<String> mappedHeaders) {
+      List<String[]> values, List<String> mappedHeaders, int csvHeaderSize) {
     List<SelfDeclaredUser> declaredUserList = new ArrayList<>();
     values
         .stream()
@@ -456,7 +456,7 @@ public class UserBulkMigrationActor extends BaseBulkUploadActor {
               int index = values.indexOf(row);
               SelfDeclaredUser selfDeclaredUser = new SelfDeclaredUser();
               for (int i = 0; i < row.length; i++) {
-                if (row.length > mappedHeaders.size()) {
+                if (row.length > csvHeaderSize) {
                   throw new ProjectCommonException(
                       ResponseCode.errorUnsupportedField.getErrorCode(),
                       ResponseCode.errorUnsupportedField.getErrorMessage(),


### PR DESCRIPTION
Instead of comparing mappedCsvHeader(which contain filtered columns like supported and mandatory fields) we will compare each row size with csvHeaders list(which contains actual columns of the uploaded csv) size.

Comparing each row is mandatory since, users may unknowing repeats the contents of a row, in that case row size may increase when compare to actual csv header size and one column value can be shifted to another column.