### PR TITLE
SB-21219 checking MUA user is present or not in the tnc request

### DIFF
--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tac/UserTnCActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tac/UserTnCActor.java
@@ -57,7 +57,7 @@ public class UserTnCActor extends BaseActor {
     // if managedUserId's terms and conditions are accepted, get userId from request
     String managedUserId = (String) request.getRequest().get(JsonKey.USER_ID);
     boolean isManagedUser = false;
-    if (StringUtils.isNotBlank(managedUserId) && !userId.equals(managedUserId)) {
+    if (StringUtils.isNotBlank(managedUserId) && !managedUserId.equals(userId)) {
       userId = managedUserId;
       isManagedUser = true;
     }

--- a/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tac/UserTnCActor.java
+++ b/actors/sunbird-lms-mw/actors/common/src/main/java/org/sunbird/learner/actors/tac/UserTnCActor.java
@@ -57,7 +57,7 @@ public class UserTnCActor extends BaseActor {
     // if managedUserId's terms and conditions are accepted, get userId from request
     String managedUserId = (String) request.getRequest().get(JsonKey.USER_ID);
     boolean isManagedUser = false;
-    if (StringUtils.isNotBlank(managedUserId)) {
+    if (StringUtils.isNotBlank(managedUserId) && !userId.equals(managedUserId)) {
       userId = managedUserId;
       isManagedUser = true;
     }

--- a/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/UserTnCActorTest.java
+++ b/actors/sunbird-lms-mw/actors/common/src/test/java/org/sunbird/learner/actors/UserTnCActorTest.java
@@ -129,8 +129,8 @@ public class UserTnCActorTest {
     reqObj.setOperation(ActorOperations.USER_TNC_ACCEPT.getValue());
     HashMap<String, Object> innerMap = new HashMap<>();
     innerMap.put(JsonKey.VERSION, version);
-    innerMap.put(JsonKey.USER_ID, version);
-    innerMap.put(JsonKey.MANAGED_BY, null);
+    innerMap.put(JsonKey.USER_ID, "someUserId");
+    innerMap.put(JsonKey.MANAGED_BY, "someUserId");
     reqObj.setRequest(innerMap);
     TestKit probe = new TestKit(system);
     ActorRef subject = system.actorOf(props);

--- a/service/app/util/RequestInterceptor.java
+++ b/service/app/util/RequestInterceptor.java
@@ -93,6 +93,7 @@ public class RequestInterceptor {
     apiHeaderIgnoreMap.put("/v1/user/exists/email", var);
     apiHeaderIgnoreMap.put("/v1/user/exists/phone", var);
     apiHeaderIgnoreMap.put("/v1/role/read", var);
+    apiHeaderIgnoreMap.put("/private/user/feed/v1/create", var);
   }
 
   private static String getUserRequestedFor(Http.Request request) {

--- a/service/conf/routes
+++ b/service/conf/routes
@@ -138,6 +138,7 @@ PATCH  /v1/org/assign/key         @controllers.organisationmanagement.KeyManagem
 #User Feed API
 GET   /v1/user/feed/:userId       @controllers.feed.FeedController.getUserFeed(userId:String,request: play.mvc.Http.Request)
 POST  /v1/user/feed/create        @controllers.feed.FeedController.createUserFeed(request: play.mvc.Http.Request)
+POST  /private/user/feed/v1/create        @controllers.feed.FeedController.createUserFeed(request: play.mvc.Http.Request)
 POST  /v1/user/feed/delete        @controllers.feed.FeedController.deleteUserFeed(request: play.mvc.Http.Request)
 PATCH  /v1/user/feed/update       @controllers.feed.FeedController.updateUserFeed(request: play.mvc.Http.Request)
 


### PR DESCRIPTION
In user TnC request we are not expecting userid for custodian-user in the request, only for MUA users we expect userid.
Recently we tighten this on these grounds.
But APP is broken since we are getting userid for custodians also from beginning, so this is conveyed to APP.
Further modified the condition.