### PR TITLE
Issue #SB-27874 feat:updating audit data with user declaration

### DIFF
--- a/service/src/main/java/org/sunbird/actor/user/UserSelfDeclarationManagementActor.java
+++ b/service/src/main/java/org/sunbird/actor/user/UserSelfDeclarationManagementActor.java
@@ -82,6 +82,10 @@ public class UserSelfDeclarationManagementActor extends BaseActor {
 
       List<UserDeclareEntity> userDeclareEntityList = new ArrayList<>();
       for (Map<String, Object> declareFieldMap : declarations) {
+        String custodianOrgId = DataCacheHandler.getConfigSettings().get(JsonKey.CUSTODIAN_ORG_ID);
+        if (((String) declareFieldMap.get(JsonKey.ORG_ID)).equalsIgnoreCase(custodianOrgId)) {
+          ProjectCommonException.throwClientErrorException(ResponseCode.invalidOrgId);
+        }
         UserDeclareEntity userDeclareEntity =
             UserUtil.createUserDeclaredObject(declareFieldMap, callerId);
         Map userInfo = userDeclareEntity.getUserInfo();

--- a/service/src/main/java/org/sunbird/util/user/UserUtil.java
+++ b/service/src/main/java/org/sunbird/util/user/UserUtil.java
@@ -775,9 +775,9 @@ public class UserUtil {
     }
     userDeclareEntity.setOperation((String) declareFieldMap.get(JsonKey.OPERATION));
     if (JsonKey.ADD.equals(userDeclareEntity.getOperation())) {
-      userDeclareEntity.setCreatedBy((String) declareFieldMap.get(JsonKey.CREATED_BY));
+      userDeclareEntity.setCreatedBy(callerId);
     } else {
-      userDeclareEntity.setUpdatedBy((String) declareFieldMap.get(JsonKey.UPDATED_BY));
+      userDeclareEntity.setUpdatedBy(callerId);
       userDeclareEntity.setStatus((String) declareFieldMap.get(JsonKey.STATUS));
     }
     if (StringUtils.isBlank((String) declareFieldMap.get(JsonKey.STATUS))) {

--- a/service/src/test/java/org/sunbird/actor/user/UserSelfDeclarationManagementActorTest.java
+++ b/service/src/test/java/org/sunbird/actor/user/UserSelfDeclarationManagementActorTest.java
@@ -11,6 +11,8 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.dispatch.Futures;
 import akka.testkit.javadsl.TestKit;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -252,10 +254,12 @@ public class UserSelfDeclarationManagementActorTest {
 
     Request request = new Request();
     request.setOperation(ActorOperations.UPDATE_USER_DECLARATIONS.getValue());
-    List<UserDeclareEntity> list = new ArrayList<>();
+    List<Map<String, Object>> list = new ArrayList<>();
     UserDeclareEntity userDeclareEntity = editOrgChangeUserDeclaredEntity();
     userDeclareEntity.setOrgId("anyOrgId");
-    list.add(userDeclareEntity);
+    ObjectMapper mapper = new ObjectMapper();
+
+    list.add(mapper.convertValue(userDeclareEntity, new TypeReference<Map<String, Object>>() {}));
     Map<String, Object> requestMap = new HashMap<>();
     requestMap.put(JsonKey.DECLARATIONS, list);
     request.setRequest(requestMap);

--- a/service/src/test/java/org/sunbird/actor/user/UserSelfDeclarationManagementActorTest.java
+++ b/service/src/test/java/org/sunbird/actor/user/UserSelfDeclarationManagementActorTest.java
@@ -56,7 +56,6 @@ import scala.concurrent.Promise;
   EsClientFactory.class,
   ElasticSearchRestHighImpl.class,
   UserUtil.class,
-  DataCacheHandler.class
 })
 @PowerMockIgnore({
   "javax.management.*",
@@ -243,6 +242,25 @@ public class UserSelfDeclarationManagementActorTest {
     Response response = probe.expectMsgClass(duration("100 second"), Response.class);
     Assert.assertTrue(null != response && response.getResponseCode() == ResponseCode.OK);
     Assert.assertEquals(JsonKey.SUCCESS, response.getResult().get(JsonKey.RESPONSE));
+  }
+
+  @Test
+  public void testUpdateUserSelfDeclaredDetails() {
+
+    TestKit probe = new TestKit(system);
+    ActorRef subject = system.actorOf(props);
+
+    Request request = new Request();
+    request.setOperation(ActorOperations.UPDATE_USER_DECLARATIONS.getValue());
+    List<UserDeclareEntity> list = new ArrayList<>();
+    UserDeclareEntity userDeclareEntity = editOrgChangeUserDeclaredEntity();
+    userDeclareEntity.setOrgId("anyOrgId");
+    list.add(userDeclareEntity);
+    Map<String, Object> requestMap = new HashMap<>();
+    requestMap.put(JsonKey.DECLARATIONS, list);
+    request.setRequest(requestMap);
+    subject.tell(request, probe.getRef());
+    probe.expectMsgClass(duration("100 second"), ProjectCommonException.class);
   }
 
   private UserDeclareEntity addUserDeclaredEntity() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27874" title="SB-27874" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />SB-27874</a>  Update audit fields along with declaration data
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
