### PR TITLE
SB-28404:[SSO > Global consent]issue:update consumer_id,object_id with root org id

### DIFF
--- a/service/src/main/java/org/sunbird/actor/user/TenantMigrationActor.java
+++ b/service/src/main/java/org/sunbird/actor/user/TenantMigrationActor.java
@@ -182,8 +182,8 @@ public class TenantMigrationActor extends BaseActor {
     // Revoke org consent
     Map<String, Object> consentReqMap = new HashMap<>();
     consentReqMap.put(JsonKey.USER_ID, (String) request.getRequest().get(JsonKey.USER_ID));
-    consentReqMap.put(JsonKey.CONSENT_CONSUMERID, orgId);
-    consentReqMap.put(JsonKey.CONSENT_OBJECTID, orgId);
+    consentReqMap.put(JsonKey.CONSENT_CONSUMERID, request.getRequest().get(JsonKey.ROOT_ORG_ID));
+    consentReqMap.put(JsonKey.CONSENT_OBJECTID, request.getRequest().get(JsonKey.ROOT_ORG_ID));
     consentReqMap.put(JsonKey.CONSENT_OBJECTTYPE, JsonKey.CONSENT_OBJECTTYPE_ORG);
     consentReqMap.put(JsonKey.STATUS, JsonKey.CONSENT_STATUS_REVOKED);
     Response consentRes =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28404" title="SB-28404" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-28404</a>  [SSO > Global consent] If user has given consent in profile for Tamil Nadu tenant and migrated to TN (Same tenant) tenant through SSO then, global consent popup is not coming after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Use root org instead of org id as consent can be revoked using school id which is not a tenant