### PR TITLE
Issue #SB-30300 fix: If note is deleted and read API is done then, 50…

### DIFF
--- a/service/src/main/java/org/sunbird/actor/notes/NotesManagementActor.java
+++ b/service/src/main/java/org/sunbird/actor/notes/NotesManagementActor.java
@@ -52,155 +52,118 @@ public class NotesManagementActor extends BaseActor {
     // object of telemetry event...
     Map<String, Object> targetObject;
     List<Map<String, Object>> correlatedObject = new ArrayList<>();
-    try {
-      Map<String, Object> req = actorMessage.getRequest();
-      if (!notesService.validUser((String) req.get(JsonKey.USER_ID), context)) {
-        ProjectCommonException.throwClientErrorException(
-            ResponseCode.invalidParameter,
-            MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.USER_ID));
-      }
-      Response response = notesService.createNote(actorMessage);
-      sender().tell(response, self());
-      String noteId = (String) response.getResult().get(JsonKey.ID);
-      targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.CREATE, null);
-      TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
-      TelemetryUtil.generateCorrelatedObject(
-          (String) req.get(JsonKey.REQUESTED_BY), JsonKey.USER, null, correlatedObject);
 
-      Map<String, String> rollup =
-          prepareRollUpForObjectType(
-              (String) req.get(JsonKey.CONTENT_ID), (String) req.get(JsonKey.COURSE_ID));
-      TelemetryUtil.addTargetObjectRollUp(rollup, targetObject);
-
-      TelemetryUtil.telemetryProcessingCall(
-          actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
-    } catch (Exception e) {
-      logger.error(context, "Exception while creating notes", e);
-      sender().tell(e, self());
+    Map<String, Object> req = actorMessage.getRequest();
+    if (!notesService.validUser((String) req.get(JsonKey.USER_ID), context)) {
+      ProjectCommonException.throwClientErrorException(
+          ResponseCode.invalidParameter,
+          MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.USER_ID));
     }
-  }
+    Response response = notesService.createNote(actorMessage);
+    sender().tell(response, self());
+    String noteId = (String) response.getResult().get(JsonKey.ID);
+    targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.CREATE, null);
+    TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
+    TelemetryUtil.generateCorrelatedObject(
+        (String) req.get(JsonKey.REQUESTED_BY), JsonKey.USER, null, correlatedObject);
 
+    Map<String, String> rollup =
+        prepareRollUpForObjectType(
+            (String) req.get(JsonKey.CONTENT_ID), (String) req.get(JsonKey.COURSE_ID));
+    TelemetryUtil.addTargetObjectRollUp(rollup, targetObject);
+    TelemetryUtil.telemetryProcessingCall(
+        actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
+  }
   private void updateNote(Request actorMessage) {
     RequestContext context = actorMessage.getRequestContext();
     logger.debug(context, "Update Note method call start");
     // object of telemetry event...
     Map<String, Object> targetObject;
     List<Map<String, Object>> correlatedObject = new ArrayList<>();
-    try {
-      String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
-      String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
-      if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
-        ProjectCommonException.throwUnauthorizedErrorException();
-      }
-      Map<String, Object> list = notesService.getNoteById(noteId, context);
-      if (list.isEmpty()) {
-        ProjectCommonException.throwClientErrorException(
-            ResponseCode.invalidParameter,
-            MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.NOTE_ID));
-      }
-      Response response = notesService.updateNote(actorMessage);
-      sender().tell(response, self());
-
-      targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.UPDATE, null);
-      TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
-      TelemetryUtil.generateCorrelatedObject(userId, JsonKey.USER, null, correlatedObject);
-      Map<String, String> rollup = new HashMap<>();
-      TelemetryUtil.addTargetObjectRollUp(rollup, targetObject);
-
-      TelemetryUtil.telemetryProcessingCall(
-          actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
-    } catch (Exception e) {
-      logger.error(context, "Exception while updating note", e);
-      sender().tell(e, self());
+    String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
+    String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
+    if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
+      ProjectCommonException.throwUnauthorizedErrorException();
     }
+    Map<String, Object> list = notesService.getNoteById(noteId, context);
+    if (list.isEmpty()) {
+      ProjectCommonException.throwClientErrorException(
+              ResponseCode.invalidParameter,
+              MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.NOTE_ID));
+    }
+    Response response = notesService.updateNote(actorMessage);
+    sender().tell(response, self());
+    targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.UPDATE, null);
+    TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
+    TelemetryUtil.generateCorrelatedObject(userId, JsonKey.USER, null, correlatedObject);
+    Map<String, String> rollup = new HashMap<>();
+    TelemetryUtil.addTargetObjectRollUp(rollup, targetObject);
+    TelemetryUtil.telemetryProcessingCall(
+            actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
   }
-
   private void getNote(Request actorMessage) {
     RequestContext context = actorMessage.getRequestContext();
     logger.debug(context, "Get Note method call start");
-    try {
-      String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
-      String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
-      if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
-        throw new ProjectCommonException(
-            ResponseCode.invalidParameterValue,
-            ResponseCode.invalidParameterValue.getErrorMessage(),
-            ResponseCode.RESOURCE_NOT_FOUND.getResponseCode());
-      }
-      Map<String, Object> request = new HashMap<>();
-      Map<String, Object> filters = new HashMap<>();
-      filters.put(JsonKey.ID, noteId);
-
-      request.put(JsonKey.FILTERS, filters);
-      Response response = new Response();
-      Map<String, Object> result = notesService.searchNotes(request, context);
-      if (!result.isEmpty() && ((Long) result.get(JsonKey.COUNT) == 0)) {
-        ProjectCommonException.throwClientErrorException(
-            ResponseCode.invalidParameter,
-            MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.NOTE_ID));
-      }
-      response.put(JsonKey.RESPONSE, result);
-      sender().tell(response, self());
-    } catch (Exception e) {
-      logger.error(context, "Exception while fetching note", e);
-      sender().tell(e, self());
+    String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
+    String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
+    if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
+      throw new ProjectCommonException(
+              ResponseCode.invalidParameterValue,
+              ResponseCode.invalidParameterValue.getErrorMessage(),
+              ResponseCode.RESOURCE_NOT_FOUND.getResponseCode());
     }
+    Map<String, Object> request = new HashMap<>();
+    Map<String, Object> filters = new HashMap<>();
+    filters.put(JsonKey.ID, noteId);
+    request.put(JsonKey.FILTERS, filters);
+    Response response = new Response();
+    Map<String, Object> result = notesService.searchNotes(request, context);
+    if (!result.isEmpty() && ((Integer) result.get(JsonKey.COUNT) == 0)) {
+      ProjectCommonException.throwResourceNotFoundException(
+              ResponseCode.resourceNotFound,
+              MessageFormat.format(ResponseCode.resourceNotFound.getErrorMessage(), JsonKey.NOTE));
+    }
+    response.put(JsonKey.RESPONSE, result);
+    sender().tell(response, self());
   }
-
   private void searchNote(Request actorMessage) {
     RequestContext context = actorMessage.getRequestContext();
     logger.debug(context, "Search Note method call start");
-    try {
-      Map<String, Object> searchQueryMap = actorMessage.getRequest();
-      searchQueryMap.put(JsonKey.REQUESTED_BY, actorMessage.getContext().get(JsonKey.REQUESTED_BY));
-      Response response = new Response();
-      Map<String, Object> result = notesService.searchNotes(searchQueryMap, context);
-      response.put(JsonKey.RESPONSE, result);
-      sender().tell(response, self());
-    } catch (Exception e) {
-      logger.error(context, "Exception while search", e);
-      sender().tell(e, self());
-    }
+    Map<String, Object> searchQueryMap = actorMessage.getRequest();
+    searchQueryMap.put(JsonKey.REQUESTED_BY, actorMessage.getContext().get(JsonKey.REQUESTED_BY));
+    Response response = new Response();
+    Map<String, Object> result = notesService.searchNotes(searchQueryMap, context);
+    response.put(JsonKey.RESPONSE, result);
+    sender().tell(response, self());
   }
-
   private void deleteNote(Request actorMessage) {
     RequestContext context = actorMessage.getRequestContext();
     logger.debug(context, "Delete Note method call start");
     // object of telemetry event...
     Map<String, Object> targetObject;
     List<Map<String, Object>> correlatedObject = new ArrayList<>();
-    try {
-      String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
-      String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
-      if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
-        ProjectCommonException.throwUnauthorizedErrorException();
-      }
-      if (!notesService.noteIdExists(noteId, context)) {
-        ProjectCommonException.throwClientErrorException(
-            ResponseCode.invalidParameter,
-            MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.NOTE_ID));
-      }
-      Response result = notesService.deleteNote(noteId, userId, context);
-      result.getResult().remove(JsonKey.RESPONSE);
-      sender().tell(result, self());
-
-      targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.DELETE, null);
-      TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
-      TelemetryUtil.generateCorrelatedObject(userId, JsonKey.USER, null, correlatedObject);
-
-      TelemetryUtil.telemetryProcessingCall(
-          actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
-    } catch (Exception e) {
-      logger.error(context, "Exception while deleting note", e);
-      sender().tell(e, self());
+    String noteId = (String) actorMessage.getContext().get(JsonKey.NOTE_ID);
+    String userId = (String) actorMessage.getContext().get(JsonKey.REQUESTED_BY);
+    if (!notesService.validateUserForNoteUpdate(userId, noteId, context)) {
+      ProjectCommonException.throwUnauthorizedErrorException();
     }
+    if (!notesService.noteIdExists(noteId, context)) {
+      ProjectCommonException.throwClientErrorException(
+              ResponseCode.invalidParameter,
+              MessageFormat.format(ResponseCode.invalidParameter.getErrorMessage(), JsonKey.NOTE_ID));
+    }
+    Response result = notesService.deleteNote(noteId, userId, context);
+    result.getResult().remove(JsonKey.RESPONSE);
+    sender().tell(result, self());
+    targetObject = TelemetryUtil.generateTargetObject(noteId, JsonKey.NOTE, JsonKey.DELETE, null);
+    TelemetryUtil.generateCorrelatedObject(noteId, JsonKey.NOTE, null, correlatedObject);
+    TelemetryUtil.generateCorrelatedObject(userId, JsonKey.USER, null, correlatedObject);
+    TelemetryUtil.telemetryProcessingCall(
+            actorMessage.getRequest(), targetObject, correlatedObject, actorMessage.getContext());
   }
-
   /** This method will handle rollup values (for contentId and courseId) in object */
   public static Map<String, String> prepareRollUpForObjectType(String contentId, String courseId) {
-
     Map<String, String> rollupMap = new HashMap<>();
-
     if (StringUtils.isBlank(courseId)) { // if courseId is blank the level 1 should be contentId
       if (StringUtils.isNotBlank(contentId)) {
         rollupMap.put("l1", contentId);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-30300" title="SB-30300" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-30300</a>  [Note Read API] If note is deleted and read API is done then, 500 error response is getting displayed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…0 error response is getting displayed

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
