### PR TITLE
Issue #SB-30251 fix: Bulk org upload API(/api/org/v1/upload) issue

### DIFF
--- a/service/src/main/java/org/sunbird/actor/bulkupload/OrgBulkUploadBackgroundJobActor.java
+++ b/service/src/main/java/org/sunbird/actor/bulkupload/OrgBulkUploadBackgroundJobActor.java
@@ -202,7 +202,9 @@ public class OrgBulkUploadBackgroundJobActor extends BaseBulkUploadBackgroundJob
     row.put(JsonKey.LOCATION_CODE, locationCodes);
     String orgId;
     row.put(JsonKey.ORG_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationType()));
-    row.put(JsonKey.ORG_SUB_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationSubType()));
+    if (org.getOrganisationSubType() != null) {
+      row.put(JsonKey.ORG_SUB_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationSubType()));
+    }
     try {
       orgId =
           upsertOrg(
@@ -242,7 +244,9 @@ public class OrgBulkUploadBackgroundJobActor extends BaseBulkUploadBackgroundJob
     Map<String, Object> row = mapper.convertValue(org, Map.class);
     row.put(JsonKey.LOCATION_CODE, locationCodes);
     row.put(JsonKey.ORG_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationType()));
-    row.put(JsonKey.ORG_SUB_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationSubType()));
+    if (org.getOrganisationSubType() != null) {
+      row.put(JsonKey.ORG_SUB_TYPE, OrgTypeValidator.getInstance().getTypeByValue(org.getOrganisationSubType()));
+    }
     try {
       row.put(JsonKey.ORGANISATION_ID, org.getId());
       upsertOrg(organisationManagementActor, row, ActorOperations.UPDATE_ORG.getValue(), context);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-30251" title="SB-30251" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-30251</a>  Bulk org upload API(/api/org/v1/upload) issue
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
